### PR TITLE
Add P2 workflow docs and deterministic scenario harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Device commands, API patterns, and device-specific knowledge are organized in th
 
 **Before creating an automation**, read `tools/automations/_guide.md` for the full workflow. For JSON schema and all trigger/condition/action types, read `tools/automations/_reference.md`.
 
-**Before adding an integration**, read `tools/integrations/_guide.md` for the full setup process.
+**Before adding an integration**, start with `tools/integrations/_discovery.md`. After the user confirms a candidate, continue to `tools/integrations/_lifecycle.md`; use `tools/integrations/_guide.md` only while navigating the `CONNECTING` phase.
 
 **After completing any action**, follow the Skill Auto-Generation rules in `TOOLS.md` to keep skill files up to date.
 
@@ -62,7 +62,7 @@ When the user asks for an automation, read `tools/automations/_guide.md` and fol
 
 ## Adding Integrations
 
-When the user asks to add an integration (Xiaomi, Philips Hue, Broadlink, etc.), read `tools/integrations/_guide.md` for the full setup process. It covers HACS installation, config flows, OAuth handling, and error recovery.
+When the user asks to add an integration (Xiaomi, Philips Hue, Broadlink, etc.), read `tools/integrations/_discovery.md` first, then `tools/integrations/_lifecycle.md` after the user confirms a candidate. Use `tools/integrations/_guide.md` only for the config-flow, OAuth, prerequisite-install, and recovery work inside `CONNECTING`.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -212,10 +212,15 @@ home-assistant/
 │   ├── _errors.md               #   Error handling & recovery
 │   ├── _services.md             #   Domain quirks (HVAC modes, brightness 0-255, etc.)
 │   ├── integrations/
-│   │   └── _guide.md            #   Integration setup (HACS, config flows, OAuth)
+│   │   ├── _discovery.md        #   Read-only discovery (passive signals + ordered LAN fallback chain)
+│   │   ├── _lifecycle.md        #   Integration lifecycle harness (selection → connection → verification)
+│   │   └── _guide.md            #   Config-flow sub-skill (HACS, OAuth, recovery during CONNECTING)
 │   ├── automations/
 │   │   ├── _guide.md            #   Automation workflow & checklist
 │   │   └── _reference.md        #   JSON schema, trigger/action types, templates
+│   ├── ha-best-practices/
+│   │   ├── SKILL.md             #   Vendored Home Assistant automation/helper guidance
+│   │   └── references/          #   Supporting best-practices references loaded during drafting
 │   ├── xiaomi-home/
 │   │   ├── _integration.md      #   Xiaomi setup, cloud regions, quirks
 │   │   ├── tv.md                #   TV commands & quirks
@@ -242,9 +247,12 @@ CLAUDE.md (always loaded)
     │                                   then tools/_errors.md if a call fails
     │
     ├─ "Before creating automation" ─→ reads tools/automations/_guide.md
+    │                                   then tools/ha-best-practices/ during Step 4 draft creation
     │                                   then _reference.md for JSON schema
     │
-    └─ "Before adding integration" ──→ reads tools/integrations/_guide.md
+    └─ "Before adding integration" ──→ reads tools/integrations/_discovery.md
+                                        then tools/integrations/_lifecycle.md
+                                        then tools/integrations/_guide.md when in CONNECTING
 
 TOOLS.md (loaded on demand)
     └─ Quick Reference table maps device names → skill files

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -9,7 +9,9 @@ This file is the entry point for all device and service knowledge. Detailed comm
 | [tools/_common.md](tools/_common.md) | ha-mcp tool patterns, network info |
 | [tools/_errors.md](tools/_errors.md) | Runtime error handling — ToolError patterns, entity states, recovery steps |
 | [tools/_services.md](tools/_services.md) | Per-domain service reference (light, climate, media_player, etc.) |
-| [tools/integrations/_guide.md](tools/integrations/_guide.md) | Integration setup — HACS, config flows, OAuth, error handling |
+| [tools/integrations/_discovery.md](tools/integrations/_discovery.md) | Read-only integration discovery — passive signals, ordered LAN fallback chain, candidate reporting |
+| [tools/integrations/_lifecycle.md](tools/integrations/_lifecycle.md) | Integration lifecycle harness — candidate confirmation, connecting, verification, skill generation |
+| [tools/integrations/_guide.md](tools/integrations/_guide.md) | Integration config-flow sub-skill — HACS, config flows, OAuth, error handling during `CONNECTING` |
 | [tools/xiaomi-home/_integration.md](tools/xiaomi-home/_integration.md) | Xiaomi Home setup, OAuth, cloud regions, shared quirks |
 | [tools/xiaomi-home/tv.md](tools/xiaomi-home/tv.md) | Xiaomi TV commands and quirks |
 | [tools/xiaomi-home/ma8-ac.md](tools/xiaomi-home/ma8-ac.md) | MA8 Air Conditioner commands and quirks |
@@ -17,18 +19,20 @@ This file is the entry point for all device and service knowledge. Detailed comm
 | [tools/printer/office-printer.md](tools/printer/office-printer.md) | Office printer setup and print commands |
 | [tools/automations/_guide.md](tools/automations/_guide.md) | **Automation creation** — workflow, required details checklist, per-domain triggers |
 | [tools/automations/_reference.md](tools/automations/_reference.md) | Automation JSON schema, all trigger/condition/action types, templates |
+| [tools/ha-best-practices/README.md](tools/ha-best-practices/README.md) | Vendored Home Assistant best-practices pack metadata and routing notes |
 
 **Before controlling a device**, read its skill file for the correct entity ID, commands, and known quirks.
 
 **For ha-mcp tool patterns** (listing devices, calling services, managing areas), read `tools/_common.md`.
 
 **For creating automations**, read `tools/automations/_guide.md` — it has the full workflow and checklist.
+When that workflow reaches Step 4, also load `tools/ha-best-practices/`. The pack is advisory and draft-only; `CLAUDE.md` remains authoritative for SmartHub-specific interaction rules.
 
 ---
 
 ## Adding New Integrations
 
-For the full integration setup process (HACS, config flows, OAuth, form handling, error recovery), read `tools/integrations/_guide.md`.
+For new integrations, start at `tools/integrations/_discovery.md`, continue to `tools/integrations/_lifecycle.md` once the user confirms a candidate, and use `tools/integrations/_guide.md` only while navigating the `CONNECTING` phase.
 
 ---
 

--- a/docs/fix-checklist.md
+++ b/docs/fix-checklist.md
@@ -47,12 +47,13 @@ Status: completed in repo on 2026-04-15 for items 5-9. Item 9a remains paused an
 
 ## P2 — Structural cleanup around the new flow
 
+Status: completed in repo on 2026-04-20 for items 10-12 and 13a. Item 13 was removed from scope on 2026-04-20.
+
 | # | Item | Description | Touches |
 |---|------|-------------|---------|
 | 10 | Add `tools/integrations/_lifecycle.md` | State machine for the full integration lifecycle: `DISCOVERED → IDENTIFIED → INTEGRATION_SELECTED → CONNECTING → CONNECTED → VERIFIED → SKILL_GENERATED`. Defines failure handling at each phase. | `tools/integrations/` (new) |
 | 11 | Demote `tools/integrations/_guide.md` to sub-skill | Keep the config-flow walker but make it callable from `_lifecycle.md`, not the primary entry point. New path: `_discovery.md` → `_lifecycle.md` → `_guide.md`. | `tools/integrations/_guide.md`, `TOOLS.md` |
 | 12 | Add `arp-scan` permission fallback chain | `arp-scan --localnet` → `nmap -sn` → `ip neigh show`. Pre-decide in the skill rather than flail on a capability error at runtime. | `tools/integrations/_discovery.md` |
-| 13 | Correct the "under 3 minutes" timing claim | Honest version: "30s on warm cache, 2–3 min on first image pull." Docker pull dominates cold start. | `README.md`, `docs/onepager.md`, marketing copy |
 | 13a | Bundle `homeassistant-ai/skills` best-practices pack | The `home-assistant-best-practices` skill from [homeassistant-ai/skills](https://github.com/homeassistant-ai/skills) fills a real gap in our automation creation: anti-pattern table (`condition: template` → `condition: numeric_state`, `wait_template` → `wait_for_trigger`, `mode: single` → `mode: restart` for motion lights), helper decision matrix (`min_max` / `threshold` / `derivative` / `utility_meter` instead of template sensors), safe entity-rename refactoring (Config-Entry blind spots), version-current gotchas (`color_temp_kelvin` not `color_temp` in 2026.3+). Portability means **vendor it into the repo** (commit a snapshot under `tools/ha-best-practices/`), not `npx skills add` at install time — installs must work offline and survive the skills repo moving. Wire it in from `tools/automations/_guide.md` Step 4 ("Draft the automation JSON") so it loads *only* when drafting an automation, not always-on — our beta users already flagged latency, and the pack is ~10 reference files. `CLAUDE.md` rules (URL-as-markdown, confirm-before-destructive, match-user-language) stay authoritative; treat the pack as advisory. Update script to re-vendor: `scripts/update-ha-best-practices.sh` that pulls a pinned git SHA. | `tools/ha-best-practices/` (new), `tools/automations/_guide.md`, `TOOLS.md`, `scripts/` (new) |
 
 ## P3 — Repo hygiene that the rest of the work exposes
@@ -72,7 +73,8 @@ Status: completed in repo on 2026-04-20 for items 14-17.
 
 - **Completed — P0 items 1–4.** Tightly coupled bundle is already landed in the repo.
 - **Completed — P1 items 5–9.** The first-win setup path, passive-first discovery flow, fingerprint corpus, empty-instance guardrail, and approval-boundary audit are landed in the repo.
-- **Later PR — P1 item 9a + P2.** Explicit HACS choice branch + structural cleanup, now that the new flow exists.
+- **Later PR — P1 item 9a.** Explicit HACS choice branch remains.
+- **Completed — P2 items 10–12 and 13a.** Lifecycle routing, ordered discovery fallback, and the vendored Home Assistant best-practices pack are landed. Item 13 was removed from scope.
 - **Completed — P3 items 14–17.** Legacy backend residue is gone, reusable templates are clarified, and historical docs are archived under `docs/archive/`.
 
 ## What this doesn't change

--- a/docs/p2-scenario-harness/issue-doc.md
+++ b/docs/p2-scenario-harness/issue-doc.md
@@ -1,0 +1,118 @@
+# P2 Deterministic Scenario Harness Issue Document
+
+**Date:** 2026-04-20
+**Scope:** Add a deterministic, no-HA scenario harness for the P2 policy path so the repo can test discovery routing, confirmation boundaries, fallback ordering, and automation best-practices loading as one coherent regression surface
+**Analyst:** Codex via review-driven-workflow
+
+## Summary
+
+This audit checked how the repo currently validates the P2 structural-cleanup behavior. Five findings remain: there is no dedicated scenario harness, the current coverage is split across isolated tests rather than end-to-end policy scenarios, there is no reusable fixture schema for discovery/confirmation flows, the automation-drafting guidance is not exercised in a scenario test, and there is no single command or validation artifact for the new harness.
+
+Overall severity is medium. The core risk is not production breakage; it is that the repo can drift away from the intended P2 conversation behavior while still passing narrow doc and hook unit tests.
+
+## Intent
+
+**Goal:** Add a stable deterministic scenario harness that gives fast, CI-friendly evidence that the P2 behavior rules hold together as a single flow without requiring a live Home Assistant instance.
+
+**Priority ranking:** regression confidence for P2 policy behavior > deterministic/stable test execution > low maintenance cost > maximizing runtime realism
+
+**Decision boundaries:** The agent may add repo-local fixtures, test utilities, and lightweight helper scripts; may extend existing tests when that reduces duplication; may document a single recommended command for running the scenario harness. The agent must not expand this workflow into a live Home Assistant smoke harness or a full conversation runner.
+
+**Stop rules:** Stop if the harness design requires a live HA instance to prove basic P2 behavior; stop if a proposed scenario runner duplicates `scripts/approval-gate.py` logic instead of exercising the real script; stop if the scope expands into a generic chat-agent simulation layer rather than the specific P2 policy path.
+
+## Findings
+
+### P1: The repo has no dedicated deterministic scenario harness for the P2 policy path
+
+**Severity:** Medium
+**Category:** Test infrastructure
+**Affected components:** `tests/`, P2 validation workflow, repo-local test entrypoints
+
+**Description:** The current repo contains doc assertions and hook unit tests, but no scenario-level harness that can replay a named P2 path from discovery through confirmation boundaries and automation draft guidance.
+
+**Impact:** The P2 behavior rules can regress independently while the narrower unit/doc tests still pass, because no single test surface models the intended path as one scenario.
+
+**Success criteria:**
+- [ ] A dedicated scenario harness test file exists under `tests/`.
+- [ ] The harness executes named P2 scenarios from structured fixtures rather than ad hoc inline strings only.
+- [ ] Running the harness verifies more than one subsystem in the same scenario path (for example discovery ordering plus approval-gate behavior).
+
+---
+
+### P2: Current P2 coverage is fragmented across isolated tests instead of cross-scenario policy assertions
+
+**Severity:** Medium
+**Category:** Coverage gaps
+**Affected components:** `tests/test_integrations_docs.py`, `tests/test_approval_gate.py`, `tests/test_automation_docs.py`
+
+**Description:** The current tests validate the discovery docs, approval gate, and automation pack separately. That proves each piece exists, but it does not prove that the expected P2 user journey routes through those pieces in the right sequence.
+
+**Impact:** A future change could preserve all the individual assertions while breaking the combined behavior that the user actually cares about.
+
+**Success criteria:**
+- [ ] At least one scenario asserts discovery-first routing, ordered fallback behavior, and confirmation-gated mutation as one coherent flow.
+- [ ] At least one scenario asserts that automation drafting reaches the best-practices pack at Step 4 rather than as a global always-on dependency.
+- [ ] Existing narrow tests remain in place or are replaced only if the scenario harness fully subsumes their coverage.
+
+---
+
+### P3: There is no reusable fixture schema for P2 discovery, confirmation, and automation-drafting scenarios
+
+**Severity:** Medium
+**Category:** Test maintainability
+**Affected components:** `tests/fixtures/` or equivalent new fixture location
+
+**Description:** The repo has no structured fixture format for representing discovery evidence, fallback constraints, approval-gate payloads, user confirmations, or expected scenario outcomes. Without that, scenario tests are likely to become brittle one-off scripts.
+
+**Impact:** The first scenario test might pass, but adding or maintaining scenarios later would be expensive and inconsistent.
+
+**Success criteria:**
+- [ ] Scenario fixtures live in a dedicated fixture directory with a documented schema.
+- [ ] The schema can represent both positive and negative paths (for example: command missing, permission denied, no confirmation, confirmed follow-up).
+- [ ] New P2 scenarios can be added without rewriting the harness logic itself.
+
+---
+
+### P4: The automation best-practices Step 4 contract is not exercised in a scenario-level test
+
+**Severity:** Medium
+**Category:** Regression safety
+**Affected components:** `tools/automations/_guide.md`, `tools/ha-best-practices/`, scenario harness coverage
+
+**Description:** The current automation-doc test confirms the pack exists and is referenced, but it does not model an automation-drafting scenario that explicitly reaches Step 4 and proves the pack is loaded only at that drafting point.
+
+**Impact:** The repo can drift toward always-on loading or lose the draft-only boundary without a scenario test catching that behavior change directly.
+
+**Success criteria:**
+- [ ] A named automation scenario checks the Step 4 transition explicitly.
+- [ ] The scenario distinguishes “draft stage” behavior from “general automation request” behavior.
+- [ ] The scenario asserts that the best-practices pack remains advisory and does not replace `CLAUDE.md` authority.
+
+---
+
+### P5: The repo lacks a single documented command and validation artifact for the deterministic P2 scenario harness
+
+**Severity:** Low
+**Category:** Developer workflow
+**Affected components:** validation docs, test invocation surface, RDW artifacts
+
+**Description:** Even after the harness is added, it needs one clear invocation path and a validation artifact that records how it proves the narrowed P2 behavior. The current P2 validation report covers the structural cleanup work, not the new scenario harness.
+
+**Impact:** Future contributors may not know which command is authoritative for P2 scenario validation, or may skip it in favor of the older narrower tests.
+
+**Success criteria:**
+- [ ] There is one clear command for running the deterministic P2 harness, either standalone or as a focused unittest module.
+- [ ] The workflow produces a validation report that records the harness command and the scenarios it covers.
+- [ ] The live docs/checklist point at the new validation path where appropriate.
+
+## Accepted Residual Risks
+
+- This harness will not prove real Home Assistant config-flow or network behavior; that remains an accepted residual risk for this workflow because the user chose the deterministic no-HA path.
+- The harness will simulate the P2 policy path, not a full OpenClaw/Codex conversation runner.
+
+## Dependencies Between Findings
+
+- P1 blocks P2 because there must be a dedicated harness before the policy flow can be asserted coherently.
+- P3 supports P1 and P2 because maintainable fixtures are required to express discovery and approval variants without duplicating test logic.
+- P4 depends on the harness structure from P1/P3 so the Step 4 automation boundary can be modeled consistently.
+- P5 depends on the implementation and validation of P1-P4 so the documented command and report reflect the real harness shape.

--- a/docs/p2-scenario-harness/plan.md
+++ b/docs/p2-scenario-harness/plan.md
@@ -1,0 +1,270 @@
+# P2 Scenario Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic, no-HA P2 scenario harness that proves discovery routing, confirmation boundaries, ordered fallback, and automation Step 4 loading as one CI-friendly regression surface.
+
+**Architecture:** Use one unittest entrypoint, `python3 -m unittest tests.test_p2_scenario_harness -v`, and drive every scenario from JSON fixtures under `tests/fixtures/p2_scenario_harness/`. The harness should shell out to the real `scripts/approval-gate.py`, read the live markdown docs under `tools/`, and assert combined behavior across discovery, approval, and automation paths without inventing a generic chat simulator or requiring a live Home Assistant instance. Keep the existing narrow tests in place as supporting unit coverage until the scenario harness proves equivalent or stronger coverage, then trim only duplicate assertions.
+
+**Tech Stack:** Python 3 `unittest`, `json`, `subprocess`, `pathlib`, repo-local Markdown fixtures, shell commands.
+
+---
+
+## File Structure
+
+- Create: `tests/test_p2_scenario_harness.py`
+- Create: `tests/fixtures/p2_scenario_harness/README.md`
+- Create: `tests/fixtures/p2_scenario_harness/discovery-routing.json`
+- Create: `tests/fixtures/p2_scenario_harness/confirmation-boundary.json`
+- Create: `tests/fixtures/p2_scenario_harness/automation-step4.json`
+- Modify: `tests/test_approval_gate.py`
+- Modify: `tests/test_automation_docs.py`
+- Modify: `tests/test_integrations_docs.py`
+- Create: `docs/p2-scenario-harness/validation-report.md`
+- Modify: `docs/p2-scenario-harness/rdw-state.json`
+
+---
+
+## Phase 1: Harness core and reusable fixture schema
+
+This phase addresses P1 and P3. It creates the dedicated harness entrypoint first, then locks the fixture schema so future scenarios do not require rewriting the runner.
+
+### Task 1: Create the deterministic harness entrypoint and named scenario loader
+
+**Files:**
+- Create: `tests/test_p2_scenario_harness.py`
+- Create: `tests/fixtures/p2_scenario_harness/discovery-routing.json`
+
+- [ ] **Step 1: Write the failing harness test**
+
+The first test should prove the module exists, discovers named fixtures, and can load a scenario definition with at least these fields: `name`, `docs`, `tool_runs`, and `expect`.
+
+```python
+def test_discovers_named_fixtures(self) -> None:
+    names = sorted(path.name for path in FIXTURE_DIR.glob("*.json"))
+    self.assertIn("discovery-routing.json", names)
+    self.assertIn("confirmation-boundary.json", names)
+```
+
+- [ ] **Step 2: Run the harness test to verify it fails**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness -v`
+Expected: failure because `tests/test_p2_scenario_harness.py` and the fixture files do not exist yet.
+
+- [ ] **Step 3: Implement the minimal runner**
+
+Create a small loader that reads every `tests/fixtures/p2_scenario_harness/*.json` file, parses each scenario, and iterates through its steps in order. Keep the runner deterministic: no randomness, no network, no HA instance, no hidden defaults.
+
+- [ ] **Step 4: Re-run the harness test**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness -v`
+Expected: pass once the module loads named fixtures and executes the scenario loop.
+
+**Phase verification:** the repo now has a dedicated deterministic harness entrypoint and a reusable fixture loader. No scenario logic should live inline in the test body beyond the loader call and assertion dispatch.
+
+### Task 2: Define the documented fixture schema and negative-path coverage
+
+**Files:**
+- Create: `tests/fixtures/p2_scenario_harness/README.md`
+- Create: `tests/fixtures/p2_scenario_harness/confirmation-boundary.json`
+
+- [ ] **Step 1: Write the failing schema test**
+
+Add a test that reads the fixture README and confirms it documents the exact fields the harness consumes, plus at least one positive and one negative path.
+
+```python
+def test_fixture_schema_is_documented(self) -> None:
+    readme = (FIXTURE_DIR / "README.md").read_text()
+    self.assertIn("name", readme)
+    self.assertIn("docs", readme)
+    self.assertIn("tool_runs", readme)
+    self.assertIn("expect", readme)
+    self.assertIn("confirmed", readme)
+    self.assertIn("denied", readme)
+```
+
+- [ ] **Step 2: Run the harness test to verify it fails**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness -v`
+Expected: failure because the schema README does not exist yet.
+
+- [ ] **Step 3: Add the schema README and a negative fixture**
+
+Document one JSON schema for all scenarios:
+
+```json
+{
+  "name": "confirmation-boundary",
+  "docs": ["tools/integrations/_guide.md"],
+  "tool_runs": [
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+      "tool_input": {"handler": "hue"},
+      "transcript": "please continue"
+    }
+  ],
+  "expect": {
+    "decision": "deny",
+    "reason_contains": "explicit confirmation"
+  }
+}
+```
+
+Use that same shape for both positive and negative cases so the harness does not need special-case parsing.
+
+- [ ] **Step 4: Re-run the harness test**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness -v`
+Expected: pass once the schema is documented and the negative-path fixture exists.
+
+**Phase verification:** the harness now has a documented fixture contract that can express both allowed and denied flows without adding runner branches.
+
+---
+
+## Phase 2: Cross-scenario policy assertions
+
+This phase addresses P2. It makes the harness prove the combined P2 journey instead of just checking isolated docs or hook behavior.
+
+### Task 3: Exercise discovery-first routing, ordered fallback, and confirmation-gated mutation in one scenario
+
+**Files:**
+- Modify: `tests/test_p2_scenario_harness.py`
+- Modify: `tests/test_approval_gate.py`
+- Modify: `tests/fixtures/p2_scenario_harness/discovery-routing.json`
+
+- [ ] **Step 1: Write the failing combined-flow test**
+
+The combined scenario should assert all of the following in one path:
+
+```python
+def test_discovery_then_confirmation_then_mutation(self) -> None:
+    self.assertIn("ha_config_entries_get", discovery_text)
+    self.assertLess(discovery_text.index("avahi-browse -atr"), discovery_text.index("arp-scan --localnet"))
+    self.assertLess(discovery_text.index("arp-scan --localnet"), discovery_text.index("nmap -sn"))
+    self.assertEqual(decision_for_unconfirmed_start, "deny")
+    self.assertEqual(decision_for_follow_up_flow_step, "allow")
+```
+
+The scenario must use the real `scripts/approval-gate.py` subprocess, not a reimplementation of its rules.
+
+- [ ] **Step 2: Run the combined-flow test to verify it fails**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate -v`
+Expected: failure because the harness does not yet assert the full discovery-to-confirmation path as one scenario.
+
+- [ ] **Step 3: Wire the harness to the real gate script and existing docs**
+
+Load `tools/integrations/_discovery.md`, `tools/integrations/_guide.md`, and `scripts/approval-gate.py` directly inside the scenario runner. Keep `tests/test_approval_gate.py` as a low-level unit suite for the hook boundary, but trim any duplication only after the scenario harness passes with the same behavior.
+
+- [ ] **Step 4: Re-run the combined-flow test**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate -v`
+Expected: pass once the scenario harness proves discovery-first routing, ordered fallback, and confirmation-gated mutation together.
+
+**Phase verification:** a single scenario now proves the policy path end to end without a live HA dependency or duplicated gate logic.
+
+---
+
+## Phase 3: Automation Step 4 contract
+
+This phase addresses P4. It makes the harness prove that the best-practices pack is loaded only when drafting automation JSON and remains advisory.
+
+### Task 4: Add the named automation drafting scenario and keep the pack boundary explicit
+
+**Files:**
+- Modify: `tests/test_p2_scenario_harness.py`
+- Modify: `tests/test_automation_docs.py`
+- Create: `tests/fixtures/p2_scenario_harness/automation-step4.json`
+
+- [ ] **Step 1: Write the failing automation scenario test**
+
+The scenario should check that `tools/automations/_guide.md` routes the pack only at Step 4 and that `tools/ha-best-practices/` stays advisory rather than replacing `CLAUDE.md` authority.
+
+```python
+def test_automation_step4_loads_pack_only_when_drafting(self) -> None:
+    self.assertIn("Step 4", guide_text)
+    self.assertIn("tools/ha-best-practices/", guide_text)
+    self.assertIn("advisory", guide_text.lower())
+    self.assertIn("CLAUDE.md", tools_router_text)
+```
+
+- [ ] **Step 2: Run the automation scenario test to verify it fails**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness tests.test_automation_docs -v`
+Expected: failure because the harness has not yet asserted the Step 4 transition as a scenario boundary.
+
+- [ ] **Step 3: Implement the Step 4 scenario**
+
+Load the live automation guide, the vendored best-practices pack, and the router text in one scenario. The scenario should distinguish:
+
+1. a general automation request that must not preload the pack, and
+2. the drafting step where the pack becomes available.
+
+Keep `tests/test_automation_docs.py` focused on pack existence and provenance, and let the scenario harness own the Step 4 behavior assertion.
+
+- [ ] **Step 4: Re-run the automation scenario test**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness tests.test_automation_docs -v`
+Expected: pass once the scenario explicitly reaches Step 4 and confirms the pack stays advisory.
+
+**Phase verification:** the harness now covers the automation-drafting boundary directly instead of relying only on a pack-existence doc test.
+
+---
+
+## Phase 4: Single command and validation artifact
+
+This phase addresses P5. It records one authoritative harness command and produces the validation artifact that future contributors can follow.
+
+### Task 5: Write the validation report and wire the RDW metadata to the harness command
+
+**Files:**
+- Create: `docs/p2-scenario-harness/validation-report.md`
+- Modify: `docs/p2-scenario-harness/rdw-state.json`
+- Modify: `tests/test_integrations_docs.py`
+
+- [ ] **Step 1: Write the failing validation-report test**
+
+Add a check that the report documents the command and the scenario names exactly:
+
+```python
+def test_validation_report_records_the_harness_command(self) -> None:
+    report = (REPO_ROOT / "docs" / "p2-scenario-harness" / "validation-report.md").read_text()
+    self.assertIn("python3 -m unittest tests.test_p2_scenario_harness -v", report)
+    self.assertIn("discovery-routing", report)
+    self.assertIn("confirmation-boundary", report)
+    self.assertIn("automation-step4", report)
+```
+
+- [ ] **Step 2: Run the full harness-focused suite to verify it fails**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v`
+Expected: failure because the report and RDW metadata do not yet exist.
+
+- [ ] **Step 3: Create the validation report and update the workflow metadata**
+
+Record the one recommended command in `docs/p2-scenario-harness/validation-report.md`, list the scenarios it covers, and capture the result of running the harness. Update `docs/p2-scenario-harness/rdw-state.json` so the `plan_doc` and `validation_report` fields point at the new plan and report.
+
+- [ ] **Step 4: Re-run the full harness-focused suite**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v`
+Expected: pass once the report records the command, the scenarios are named explicitly, and the RDW metadata points at the right files.
+
+**Phase verification:** the repo has one clear harness command, one validation artifact, and workflow metadata that points future readers at the same path.
+
+---
+
+## Coverage Check
+
+- P1 is covered by Task 1, which creates the dedicated deterministic harness entrypoint under `tests/`.
+- P3 is covered by Task 2, which adds the documented fixture schema and both positive and negative fixture shapes under `tests/fixtures/p2_scenario_harness/`.
+- P2 is covered by Task 3, which proves discovery-first routing, ordered fallback, and confirmation-gated mutation together in one scenario instead of only in isolated tests.
+- P4 is covered by Task 4, which adds the automation drafting scenario and explicitly checks the Step 4 load boundary for `tools/ha-best-practices/`.
+- P5 is covered by Task 5, which writes the validation report, records the single command, and updates the RDW metadata to point at the harness artifacts.
+
+## Self-Check
+
+- All five findings map to concrete tasks above.
+- Every phase has a verification command and expected result.
+- No placeholders such as `TBD`, `TODO`, or “write tests for the above” remain.
+- File paths are explicit and consistent across the file structure, tasks, and verification sections.
+- The plan respects the Intent ordering: regression confidence first, deterministic/stable execution second, low-maintenance fixture schema third, runtime realism intentionally not expanded beyond repo-local subprocesses.

--- a/docs/p2-scenario-harness/rdw-state.json
+++ b/docs/p2-scenario-harness/rdw-state.json
@@ -1,0 +1,81 @@
+{
+  "workflow_id": "rdw-20260420-p2-scenario-harness",
+  "started": "2026-04-20T00:00:00+08:00",
+  "current_stage": "complete",
+  "artifacts": {
+    "issue_doc": "docs/p2-scenario-harness/issue-doc.md",
+    "plan_doc": "docs/p2-scenario-harness/plan.md",
+    "validation_report": "docs/p2-scenario-harness/validation-report.md"
+  },
+  "stages_completed": [
+    "document",
+    "plan",
+    "implement",
+    "validate",
+    "learn"
+  ],
+  "phases": {
+    "total": 4,
+    "completed": [
+      "phase-1-harness-core-and-fixtures",
+      "phase-2-cross-scenario-policy-assertions",
+      "phase-3-automation-step4-contract",
+      "phase-4-command-and-validation-artifact"
+    ],
+    "current": null,
+    "failed": []
+  },
+  "review_log": [
+    {
+      "stage": "document",
+      "round": 1,
+      "result": "PASS",
+      "note": "Completeness review passed: the issue doc has a full Intent section, five discrete findings, concrete success criteria, and explicit dependencies."
+    },
+    {
+      "stage": "plan",
+      "round": 1,
+      "result": "PASS",
+      "note": "Cross-reference review passed: the plan maps all five findings to concrete tasks, includes per-phase verification commands, and introduces no scope creep beyond the issue doc."
+    },
+    {
+      "stage": "implement-phase-1",
+      "round": 1,
+      "result": "APPROVED",
+      "note": "Added `tests/test_p2_scenario_harness.py` plus the `tests/fixtures/p2_scenario_harness/` schema README and initial JSON fixtures. Verified locally with `python3 -m unittest tests.test_p2_scenario_harness -v` (3 tests OK)."
+    },
+    {
+      "stage": "implement-phase-2",
+      "round": 1,
+      "result": "APPROVED",
+      "note": "Extended the harness with a combined discovery/confirmation scenario that shells out to the real `scripts/approval-gate.py`, updated the `discovery-routing.json` fixture to cover read-only discovery, denied mutation, and confirmed follow-up, and verified locally with `python3 -m unittest tests.test_p2_scenario_harness -v` (4 tests OK) plus `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate -v` (10 tests OK)."
+    },
+    {
+      "stage": "implement-phase-3",
+      "round": 1,
+      "result": "APPROVED",
+      "note": "Added the `automation-step4` scenario to the harness, created its JSON fixture, narrowed `tests/test_automation_docs.py` to vendored-pack provenance checks, and verified locally with `python3 -m unittest tests.test_p2_scenario_harness -v` (5 tests OK) plus `python3 -m unittest tests.test_p2_scenario_harness tests.test_automation_docs -v` (6 tests OK)."
+    },
+    {
+      "stage": "implement-phase-4",
+      "round": 1,
+      "result": "APPROVED",
+      "note": "Added `docs/p2-scenario-harness/validation-report.md`, pinned the harness command/scenario names with a focused regression check in `tests/test_integrations_docs.py`, and verified locally with `python3 -m unittest tests.test_integrations_docs.IntegrationDocsTests.test_validation_report_records_the_harness_command -v`."
+    },
+    {
+      "stage": "validate",
+      "round": 1,
+      "result": "PASS",
+      "note": "Fresh validation passed with `python3 -m unittest tests.test_p2_scenario_harness -v` (5 tests OK) and `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v` (16 tests OK)."
+    },
+    {
+      "stage": "learn",
+      "round": 1,
+      "result": "SKIPPED",
+      "note": "No discoveries, phase failures, or validation regressions were recorded, so memory capture was skipped."
+    }
+  ],
+  "tier": 2,
+  "discoveries": [],
+  "learnings_captured": []
+}

--- a/docs/p2-scenario-harness/validation-report.md
+++ b/docs/p2-scenario-harness/validation-report.md
@@ -1,0 +1,30 @@
+# P2 Scenario Harness Validation Report
+
+**Date:** 2026-04-20
+**Scope:** Deterministic, no-HA validation of the P2 scenario harness
+
+## Recommended Command
+
+```bash
+python3 -m unittest tests.test_p2_scenario_harness -v
+```
+
+## Scenarios Covered
+
+- `discovery-routing`
+- `confirmation-boundary`
+- `automation-step4`
+
+## Validation Result
+
+**PASS**
+
+Fresh run on 2026-04-20:
+
+- 5 tests executed
+- 0 failures
+- 0 errors
+
+## Notes
+
+This harness is intentionally deterministic. It exercises the repo-local P2 policy path without a live Home Assistant instance and uses the real approval gate subprocess plus markdown docs under `tools/` as inputs.

--- a/docs/p2-structural-cleanup/issue-doc.md
+++ b/docs/p2-structural-cleanup/issue-doc.md
@@ -1,0 +1,102 @@
+# P2 Structural Cleanup Issue Document
+
+**Date:** 2026-04-20
+**Scope:** P2 items 10-12 and 13a from `docs/fix-checklist.md`, covering the integration-flow skill architecture, discovery fallback behavior, and the vendored automation best-practices pack
+**Analyst:** Codex via review-driven-workflow
+
+## Summary
+
+This audit checked whether the repository structure around the newly landed first-device flow matches the intended P2 follow-up work. Four findings remain: the integration flow has no lifecycle orchestrator, the config-flow walker still acts as the primary entrypoint, the discovery skill does not define a runtime-safe network-scan fallback chain, and the automation drafting path still lacks the vendored Home Assistant best-practices pack.
+
+Overall severity is medium. The main risk is not runtime breakage; it is that the repo now has a stronger first-device path than its surrounding skill architecture, documentation, and automation-authoring guidance actually support.
+
+## Intent
+
+**Goal:** Finish the post-P1 structural cleanup so the first-device experience stays coherent end-to-end, the routing docs tell the truth, and automation drafting picks up the missing Home Assistant best-practices guidance without adding always-on latency.
+
+**Priority ranking:** time-to-first-device-control clarity > accurate operator guidance > keeping the skill/router architecture consistent > minimizing diff size
+
+**Decision boundaries:** The agent may add or reorganize skill documents, update router/docs references, vendor a pinned upstream best-practices snapshot, and add repo-local maintenance scripts. The agent must stop and ask before undoing unrelated user work or recreating a live doc the user intentionally deleted.
+
+**Stop rules:** Stop if an intended P2 touchpoint has already been intentionally removed from the worktree and should stay removed; stop if the upstream best-practices pack cannot be vendored with a clear pinned revision and repo-local provenance; stop if implementing the lifecycle refactor would require changing the approval-gate safety boundary rather than preserving it.
+
+## Findings
+
+### P1: The integration flow lacks a lifecycle-level orchestrator for the post-discovery path
+
+**Severity:** Medium
+**Category:** Architecture clarity
+**Affected components:** `tools/integrations/`, `TOOLS.md`
+
+**Description:** The repo now has a discovery-first integration flow, but there is no dedicated lifecycle document that defines the full state machine from discovered evidence through verified first control and skill generation. The current structure leaves the transition points and failure handling implicit.
+
+**Impact:** Agents can enter the right discovery flow but still make inconsistent handoffs between discovery, config entry selection, connection, verification, and follow-on skill generation. That weakens the "one first win" setup path that P1 established.
+
+**Success criteria:**
+- [ ] `test -f tools/integrations/_lifecycle.md` succeeds.
+- [ ] `grep -n "DISCOVERED.*IDENTIFIED.*INTEGRATION_SELECTED.*CONNECTING.*CONNECTED.*VERIFIED.*SKILL_GENERATED" tools/integrations/_lifecycle.md` returns a state-sequence definition.
+- [ ] `grep -n "failure" tools/integrations/_lifecycle.md` shows explicit recovery or escalation handling for lifecycle phases.
+
+---
+
+### P2: `tools/integrations/_guide.md` still acts like the primary integration entrypoint instead of a sub-skill
+
+**Severity:** Medium
+**Category:** Skill routing
+**Affected components:** `tools/integrations/_guide.md`, `TOOLS.md`, routing docs that point agents at the integration flow
+
+**Description:** The current guide mixes entrypoint policy, HACS behavior, dashboard prompting, config-flow walking, and runtime recovery in one place. That made sense before the discovery-first work, but it now leaves the config-flow walker positioned as the main integration interface rather than as a lower-level helper called by a lifecycle skill.
+
+**Impact:** Agents can skip the intended discovery-to-lifecycle handoff, and the repo keeps multiple competing "start here" instructions for the same flow.
+
+**Success criteria:**
+- [ ] `grep -n "_lifecycle.md" TOOLS.md tools/integrations/_discovery.md tools/integrations/_guide.md` shows `_lifecycle.md` as the primary route between discovery and guided config work.
+- [ ] `grep -n "sub-skill\\|called from" tools/integrations/_guide.md` shows `_guide.md` described as a subordinate config-flow helper rather than the top-level entrypoint.
+- [ ] Current-facing routing docs no longer instruct agents to enter the integration flow through `_guide.md` alone.
+
+---
+
+### P3: The discovery skill does not define a capability-aware scan fallback chain before runtime failures happen
+
+**Severity:** Medium
+**Category:** Reliability
+**Affected components:** `tools/integrations/_discovery.md`
+
+**Description:** `_discovery.md` correctly prefers passive discovery, but it does not yet codify the fallback ladder for active network evidence gathering when privileged or optional tools are unavailable. The checklist explicitly calls for a pre-decided chain: `arp-scan --localnet` → `nmap -sn` → `ip neigh show`.
+
+**Impact:** Agents can waste time trying unsupported commands in an arbitrary order, or mistake a permission/tooling failure for the absence of discoverable devices.
+
+**Success criteria:**
+- [ ] `grep -n "arp-scan --localnet" tools/integrations/_discovery.md` returns the first active-scan step.
+- [ ] `grep -n "nmap -sn" tools/integrations/_discovery.md` returns the second fallback step.
+- [ ] `grep -n "ip neigh show" tools/integrations/_discovery.md` returns the final fallback step.
+- [ ] `_discovery.md` distinguishes permission/tool-availability failures from "no candidate devices found" outcomes.
+
+---
+
+### P4: The automation drafting path still lacks the vendored Home Assistant best-practices pack
+
+**Severity:** Medium
+**Category:** Authoring guidance
+**Affected components:** `tools/automations/_guide.md`, `tools/ha-best-practices/`, `TOOLS.md`, `scripts/`
+
+**Description:** The automation guide currently tells agents to draft automation JSON directly after gathering details and entity IDs. It does not load the best-practices reference pack that the checklist identified as missing, so agents lack the intended anti-pattern guidance, helper-selection matrix, rename caveats, and version-current field conventions during draft creation.
+
+**Impact:** Automation drafts are more likely to repeat avoidable Home Assistant anti-patterns, and the repo misses a reusable guidance layer that should be available offline without adding always-on skill-loading cost.
+
+**Success criteria:**
+- [ ] `test -d tools/ha-best-practices` succeeds.
+- [ ] `grep -n "home-assistant-best-practices\\|ha-best-practices" tools/automations/_guide.md TOOLS.md` shows the pack wired into the drafting step as advisory guidance.
+- [ ] `test -f scripts/update-ha-best-practices.sh` succeeds.
+- [ ] The vendored pack records a pinned upstream revision or equivalent provenance so it can be refreshed deliberately.
+
+## Accepted Residual Risks
+
+- The vendored best-practices snapshot will age over time between explicit refreshes; that is acceptable as long as the repo carries a clear pinned revision and a refresh script.
+- The lifecycle refactor is intentionally documentation-first. It improves routing consistency, but it does not itself add new Home Assistant runtime capabilities.
+
+## Dependencies Between Findings
+
+- P1 blocks P2 because `_guide.md` cannot be cleanly demoted until `_lifecycle.md` exists as the new orchestrator.
+- P2 and P3 both feed the same first-device setup path and should land together so routing and fallback behavior do not drift.
+- P4 is independent of P1-P3 at runtime, but it should still respect the same routing/latency principles established elsewhere in the repo.

--- a/docs/p2-structural-cleanup/plan.md
+++ b/docs/p2-structural-cleanup/plan.md
@@ -1,0 +1,218 @@
+# P2 Structural Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land P2 items 10-12 and 13a so the integration flow routes through a lifecycle skill, discovery has an explicit fallback ladder, and automation drafting can load a vendored Home Assistant best-practices pack offline.
+
+**Architecture:** Treat the integration-flow cleanup as one documentation-and-routing slice: introduce `tools/integrations/_lifecycle.md`, reposition `_guide.md` as the config-flow sub-skill, and update every live router (`CLAUDE.md`, `TOOLS.md`, `README.md`, docs tests) to match. Treat the automation best-practices pack as a separate slice: vendor a pinned upstream snapshot under `tools/ha-best-practices/`, add a refresh script, and wire the pack into the automation drafting step without making it always-on.
+
+**Tech Stack:** Markdown skill files, Bash maintenance script, Python `unittest` doc assertions, `git`/`grep`, GitHub-hosted upstream reference snapshot
+
+---
+
+### Task 1: Introduce the lifecycle entrypoint and reroute the integration flow
+
+**Files:**
+- Create: `tools/integrations/_lifecycle.md`
+- Modify: `tools/integrations/_guide.md`
+- Modify: `tools/integrations/_discovery.md`
+- Modify: `TOOLS.md`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `tests/test_integrations_docs.py`
+- Modify: `docs/p2-structural-cleanup/rdw-state.json`
+
+- [ ] **Step 1: Capture the current routing baseline before edits**
+
+Run:
+```bash
+grep -RIn "Before adding an integration\\|tools/integrations/_guide.md\\|tools/integrations/_discovery.md" CLAUDE.md TOOLS.md README.md tools tests 2>/dev/null
+```
+
+Expected: direct `_guide.md` routing still appears in `CLAUDE.md`, `TOOLS.md`, and `README.md`, while `_discovery.md` already exists as the passive entrypoint.
+
+- [ ] **Step 2: Write the new lifecycle skill**
+
+Create `tools/integrations/_lifecycle.md` with:
+- The lifecycle states in one explicit sequence:
+  `DISCOVERED → IDENTIFIED → INTEGRATION_SELECTED → CONNECTING → CONNECTED → VERIFIED → SKILL_GENERATED`
+- Per-state sections describing:
+  - entry conditions
+  - required data
+  - allowed actions
+  - success exit condition
+  - failure handling / escalation boundary
+- Routing rules that make `_discovery.md` the read-only entrypoint and `_guide.md` the config-flow helper used only during `CONNECTING`
+- Verification rules that preserve the P1 “one new device-backed, non-system entity + one verified read or control action” contract before claiming success
+
+- [ ] **Step 3: Demote `_guide.md` to a subordinate config-flow walker**
+
+Edit `tools/integrations/_guide.md` so the opening section:
+- calls it a sub-skill / helper
+- states that `_discovery.md` and `_lifecycle.md` are the primary path
+- keeps the existing config-flow, OAuth, and recovery guidance intact
+- points failures back to the lifecycle state handling rather than presenting `_guide.md` as the first stop
+
+- [ ] **Step 4: Update discovery to hand off into lifecycle and define the exact fallback chain**
+
+Edit `tools/integrations/_discovery.md` so the active-scan section is:
+1. `arp-scan --localnet`
+2. `nmap -sn`
+3. `ip neigh show`
+
+Also add explicit decision text for:
+- missing command vs insufficient privilege vs empty results
+- when to continue down the chain
+- when discovery should stop and report “no candidates found”
+- handing confirmed candidates into `tools/integrations/_lifecycle.md`
+
+- [ ] **Step 5: Update every live router to the new integration path**
+
+Edit:
+- `TOOLS.md`
+- `CLAUDE.md`
+- `README.md`
+
+So that all integration-routing language follows:
+`tools/integrations/_discovery.md` → `tools/integrations/_lifecycle.md` → `tools/integrations/_guide.md`
+
+Also update the README project structure / knowledge-flow sections to mention `_lifecycle.md`.
+
+- [ ] **Step 6: Expand integration docs tests before validating manually**
+
+Update `tests/test_integrations_docs.py` to assert:
+- `_lifecycle.md` exists and contains the full state sequence
+- `_discovery.md` routes to `_lifecycle.md`
+- the active fallback chain order is `arp-scan --localnet` then `nmap -sn` then `ip neigh show`
+- `_guide.md` describes itself as a sub-skill/helper
+- `CLAUDE.md`, `TOOLS.md`, and `README.md` no longer route integrations directly to `_guide.md`
+
+- [ ] **Step 7: Run the focused integration doc tests**
+
+Run:
+```bash
+python3 -m unittest tests.test_integrations_docs -v
+```
+
+Expected: PASS with the lifecycle/routing assertions green.
+
+### Task 2: Vendor the Home Assistant best-practices pack and wire it into automation drafting
+
+**Files:**
+- Create: `tools/ha-best-practices/` (vendored snapshot + provenance file)
+- Create: `scripts/update-ha-best-practices.sh`
+- Modify: `tools/automations/_guide.md`
+- Modify: `TOOLS.md`
+- Modify: `README.md`
+- Create or Modify: `tests/test_automation_docs.py`
+- Modify: `docs/p2-structural-cleanup/rdw-state.json`
+
+- [ ] **Step 1: Inspect the upstream pack and record a pinned revision**
+
+Gather from the upstream `homeassistant-ai/skills` repository:
+- the commit SHA being vendored
+- the file list for the `home-assistant-best-practices` pack
+- enough source context to preserve the pack’s anti-pattern guidance, helper matrix, rename warnings, and version-current gotchas
+
+Expected: a concrete revision is chosen before any repo-local vendoring starts.
+
+- [ ] **Step 2: Vendor the snapshot under `tools/ha-best-practices/`**
+
+Add the upstream content under `tools/ha-best-practices/` and include a short provenance file (for example `README.md`) that records:
+- upstream repo URL
+- pinned commit SHA
+- refresh date
+- which upstream directory or files were copied
+
+Expected: the repo contains an offline, committed snapshot rather than an install-time fetch.
+
+- [ ] **Step 3: Add a deterministic refresh script**
+
+Create `scripts/update-ha-best-practices.sh` that:
+- accepts no required arguments
+- clones or fetches the upstream repo into a temp dir
+- checks out the pinned SHA stored in the script or provenance file
+- replaces the local vendored snapshot
+- prints the SHA it synced
+
+Also make the script fail fast (`set -euo pipefail`) and avoid touching unrelated files.
+
+- [ ] **Step 4: Wire the pack into the automation drafting step only**
+
+Edit `tools/automations/_guide.md` so Step 4 explicitly says to load `tools/ha-best-practices/` when drafting automation JSON, and clarify that:
+- the pack is advisory
+- `CLAUDE.md` remains authoritative for user-facing behavior
+- the pack is loaded only during draft creation, not during every automation interaction
+
+Update `TOOLS.md` so users/agents can find the pack from the automation workflow without making it a universal prerequisite.
+
+- [ ] **Step 5: Add automation doc coverage for the vendored pack**
+
+Create or update `tests/test_automation_docs.py` to assert:
+- `tools/ha-best-practices/` exists
+- the provenance metadata includes a pinned upstream reference
+- `tools/automations/_guide.md` mentions the pack in Step 4 / draft creation
+- `TOOLS.md` points automation work to the pack without declaring it authoritative over `CLAUDE.md`
+- `scripts/update-ha-best-practices.sh` exists and references the chosen upstream repo / SHA handling
+
+- [ ] **Step 6: Run the focused automation doc tests**
+
+Run:
+```bash
+python3 -m unittest tests.test_automation_docs -v
+```
+
+Expected: PASS with the vendoring/routing assertions green.
+
+### Task 3: Validate the combined P2 slice and update workflow artifacts
+
+**Files:**
+- Modify: `docs/fix-checklist.md`
+- Create: `docs/p2-structural-cleanup/validation-report.md`
+- Modify: `docs/p2-structural-cleanup/rdw-state.json`
+
+- [ ] **Step 1: Mark the checklist scope and completion state accurately**
+
+Update `docs/fix-checklist.md` so:
+- item `13` stays removed from P2 scope
+- items `10-12` and `13a` reflect the implementation status reached by this work
+
+- [ ] **Step 2: Run the routing/pack verification commands**
+
+Run:
+```bash
+grep -RIn "Before adding an integration\\|tools/integrations/_guide.md\\|tools/integrations/_lifecycle.md" CLAUDE.md TOOLS.md README.md tools tests 2>/dev/null
+grep -RIn "arp-scan --localnet\\|nmap -sn\\|ip neigh show" tools/integrations/_discovery.md tests/test_integrations_docs.py 2>/dev/null
+grep -RIn "ha-best-practices\\|home-assistant-best-practices" TOOLS.md tools/automations/_guide.md tools/ha-best-practices scripts/update-ha-best-practices.sh tests/test_automation_docs.py 2>/dev/null
+```
+
+Expected: the integration routing points at `_lifecycle.md`, the fallback chain appears in the right order, and the automation best-practices pack is discoverable through the intended files.
+
+- [ ] **Step 3: Run the full focused docs suite for touched surfaces**
+
+Run:
+```bash
+python3 -m unittest tests.test_integrations_docs tests.test_automation_docs tests.test_setup_docs tests.test_recovery_docs -v
+```
+
+Expected: PASS with no regressions in setup or recovery doc contracts.
+
+- [ ] **Step 4: Write the validation report with real evidence**
+
+Create `docs/p2-structural-cleanup/validation-report.md` that records:
+- each finding P1-P4
+- the grep/unittest commands run
+- PASS/FAIL status with actual outputs summarized
+
+- [ ] **Step 5: Mark the workflow complete**
+
+Update `docs/p2-structural-cleanup/rdw-state.json` with:
+- `artifacts.validation_report`
+- completed stages/phases
+- review log entries for plan, implementation phases, and validation
+
+## Self-Review
+
+- Coverage check: Task 1 maps to findings P1-P3, Task 2 maps to P4, and Task 3 validates all four findings plus the item-13 scope removal.
+- Placeholder scan: no `TODO`, `TBD`, or undefined upstream-vendoring steps remain.
+- Scope check: limited to items `10-12` and `13a`; the removed timing-claim item is intentionally excluded.

--- a/docs/p2-structural-cleanup/rdw-state.json
+++ b/docs/p2-structural-cleanup/rdw-state.json
@@ -1,0 +1,67 @@
+{
+  "workflow_id": "rdw-20260420-p2-structural-cleanup",
+  "started": "2026-04-20T00:00:00+08:00",
+  "current_stage": "complete",
+  "artifacts": {
+    "issue_doc": "docs/p2-structural-cleanup/issue-doc.md",
+    "plan_doc": "docs/p2-structural-cleanup/plan.md",
+    "validation_report": "docs/p2-structural-cleanup/validation-report.md"
+  },
+  "stages_completed": [
+    "document",
+    "plan",
+    "implement",
+    "validate",
+    "learn"
+  ],
+  "phases": {
+    "total": 2,
+    "completed": [
+      "phase-1-integration-lifecycle-routing",
+      "phase-2-automation-best-practices-pack"
+    ],
+    "current": null,
+    "failed": []
+  },
+  "review_log": [
+    {
+      "stage": "document",
+      "round": 1,
+      "result": "PASS",
+      "note": "Inline completeness review passed, then the issue doc was narrowed per user direction to items 10-12 and 13a only. The final issue doc contains a full Intent section, four discrete findings, concrete validation criteria, and explicit dependencies."
+    },
+    {
+      "stage": "plan",
+      "round": 1,
+      "result": "PASS",
+      "note": "Plan written inline with three tasks: integration lifecycle/routing, vendored automation best-practices pack, and focused validation. Coverage matches all four findings in the narrowed issue doc."
+    },
+    {
+      "stage": "implement-phase-1",
+      "round": 1,
+      "result": "APPROVED",
+      "note": "Added `tools/integrations/_lifecycle.md`, rerouted `CLAUDE.md` / `TOOLS.md` / `README.md` through discovery → lifecycle → guide, updated `_discovery.md` to the ordered `arp-scan --localnet` → `nmap -sn` → `ip neigh show` fallback chain, and passed `python3 -m unittest tests.test_integrations_docs -v`."
+    },
+    {
+      "stage": "implement-phase-2",
+      "round": 1,
+      "result": "APPROVED",
+      "note": "Vendored the upstream `home-assistant-best-practices` snapshot under `tools/ha-best-practices/` at pinned commit `e503410aa2c412dd27579562f194ee6614314dd8`, added `scripts/update-ha-best-practices.sh`, wired the pack into `tools/automations/_guide.md` and `TOOLS.md`, and passed `python3 -m unittest tests.test_automation_docs -v`."
+    },
+    {
+      "stage": "validate",
+      "round": 1,
+      "result": "PASS",
+      "note": "Validation report written to `docs/p2-structural-cleanup/validation-report.md`. Routing/fallback/provenance grep checks passed, `./scripts/update-ha-best-practices.sh` synced successfully, and `python3 -m unittest tests.test_integrations_docs tests.test_automation_docs tests.test_setup_docs tests.test_recovery_docs -v` passed (6 tests OK)."
+    },
+    {
+      "stage": "learn",
+      "round": 1,
+      "result": "SKIPPED",
+      "note": "No implementation discoveries, review failures, or validation regressions were recorded, so memory capture was skipped."
+    }
+  ],
+  "tier": 2,
+  "discoveries": [],
+  "learnings_captured": []
+}

--- a/docs/p2-structural-cleanup/validation-report.md
+++ b/docs/p2-structural-cleanup/validation-report.md
@@ -1,0 +1,65 @@
+# P2 Structural Cleanup Validation Report
+
+**Date:** 2026-04-20
+**Scope:** P2 items 10-12 and 13a from `docs/fix-checklist.md`
+**Result:** PASS
+
+## Scope Check
+
+- `docs/fix-checklist.md` now records: `Status: completed in repo on 2026-04-20 for items 10-12 and 13a. Item 13 was removed from scope on 2026-04-20.`
+- Validation covered the four findings in `docs/p2-structural-cleanup/issue-doc.md`.
+
+## Commands Run
+
+```bash
+grep -n "Before adding an integration" CLAUDE.md
+grep -n "tools/integrations/_discovery.md\|tools/integrations/_lifecycle.md" \
+  CLAUDE.md TOOLS.md README.md tools/integrations/_guide.md \
+  tools/integrations/_discovery.md tools/integrations/_lifecycle.md
+
+grep -n "arp-scan --localnet\|nmap -sn\|ip neigh show" \
+  tools/integrations/_discovery.md tests/test_integrations_docs.py
+
+grep -n "tools/ha-best-practices/\|home-assistant-best-practices\|Pinned commit" \
+  TOOLS.md tools/automations/_guide.md tools/ha-best-practices/README.md \
+  scripts/update-ha-best-practices.sh tests/test_automation_docs.py
+
+./scripts/update-ha-best-practices.sh
+
+python3 -m unittest \
+  tests.test_integrations_docs \
+  tests.test_automation_docs \
+  tests.test_setup_docs \
+  tests.test_recovery_docs -v
+
+grep -n "DISCOVERED → IDENTIFIED → INTEGRATION_SELECTED → CONNECTING → CONNECTED → VERIFIED → SKILL_GENERATED" \
+  tools/integrations/_lifecycle.md
+grep -n "failure handling" tools/integrations/_lifecycle.md
+
+test -f tools/integrations/_lifecycle.md && echo LIFECYCLE_OK
+test -d tools/ha-best-practices && echo PACK_OK
+test -f scripts/update-ha-best-practices.sh && echo SCRIPT_OK
+
+grep -n "Status: completed in repo on 2026-04-20 for items 10-12 and 13a" docs/fix-checklist.md
+grep -n "Item 13 was removed from scope" docs/fix-checklist.md
+```
+
+## Results by Finding
+
+| Finding | Requirement | Evidence | Result |
+|---|---|---|---|
+| P1 | Add lifecycle orchestrator for the post-discovery path | `tools/integrations/_lifecycle.md` exists; the full lifecycle state sequence and failure-handling text were found by grep; integration routing in `CLAUDE.md`, `TOOLS.md`, and `README.md` now points through discovery → lifecycle → guide | PASS |
+| P2 | Demote `_guide.md` to a sub-skill | `tools/integrations/_guide.md` now identifies itself as a sub-skill for `CONNECTING`; live routers no longer tell agents to enter integrations through `_guide.md` alone | PASS |
+| P3 | Define the ordered active-scan fallback chain | `tools/integrations/_discovery.md` and `tests/test_integrations_docs.py` both show the ordered chain `arp-scan --localnet` → `nmap -sn` → `ip neigh show`; command-missing and permission failure modes are documented as tooling constraints, not “no devices found” | PASS |
+| P4 | Vendor the best-practices pack and load it only during automation drafting | `tools/ha-best-practices/` exists with upstream provenance and pinned commit `e503410aa2c412dd27579562f194ee6614314dd8`; `tools/automations/_guide.md` loads it only at Step 4; `TOOLS.md` marks it advisory; `./scripts/update-ha-best-practices.sh` completed successfully | PASS |
+
+## Test Suite Result
+
+`python3 -m unittest tests.test_integrations_docs tests.test_automation_docs tests.test_setup_docs tests.test_recovery_docs -v`
+
+- Ran 6 tests
+- Result: `OK`
+
+## Conclusion
+
+The narrowed P2 scope is complete in the repo: items 10-12 and 13a are validated, and item 13 is removed from scope in the checklist.

--- a/scripts/update-ha-best-practices.sh
+++ b/scripts/update-ha-best-practices.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pinned commit for tools/ha-best-practices/.
+PINNED_COMMIT="e503410aa2c412dd27579562f194ee6614314dd8"
+UPSTREAM_REPO="https://github.com/homeassistant-ai/skills.git"
+UPSTREAM_PATH="skills/home-assistant-best-practices"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/tools/ha-best-practices"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+git clone "${UPSTREAM_REPO}" "${TMP_DIR}/repo" >/dev/null 2>&1
+git -C "${TMP_DIR}/repo" checkout "${PINNED_COMMIT}" >/dev/null 2>&1
+
+rm -rf "${TARGET_DIR}/references" "${TARGET_DIR}/SKILL.md"
+cp "${TMP_DIR}/repo/${UPSTREAM_PATH}/SKILL.md" "${TARGET_DIR}/SKILL.md"
+cp -R "${TMP_DIR}/repo/${UPSTREAM_PATH}/references" "${TARGET_DIR}/references"
+
+cat > "${TARGET_DIR}/README.md" <<EOF
+# Home Assistant Best Practices Snapshot
+
+- Upstream repository: <https://github.com/homeassistant-ai/skills>
+- Vendored skill path: \`skills/home-assistant-best-practices\`
+- Pinned commit: \`${PINNED_COMMIT}\`
+- Vendored on: \`$(date +%F)\`
+- Included files: upstream \`SKILL.md\` plus the \`references/\` directory used by that skill
+
+This directory is a committed offline snapshot of the upstream \`home-assistant-best-practices\` pack.
+
+Local routing rules for this repo:
+
+- Load this pack only when \`tools/automations/_guide.md\` reaches Step 4, "Draft the automation JSON".
+- Treat the pack as advisory Home Assistant guidance for automation structure, helpers, refactoring safety, and domain-specific gotchas.
+- \`CLAUDE.md\` remains authoritative for SmartHub-specific user interaction rules such as confirmation boundaries, language matching, and markdown-link requirements.
+
+Use \`scripts/update-ha-best-practices.sh\` to refresh this snapshot deliberately.
+EOF
+
+echo "Synced tools/ha-best-practices at pinned commit ${PINNED_COMMIT}"

--- a/tests/fixtures/p2_scenario_harness/README.md
+++ b/tests/fixtures/p2_scenario_harness/README.md
@@ -1,0 +1,36 @@
+# P2 Scenario Harness Fixtures
+
+Each scenario fixture is a JSON object with four required top-level fields:
+
+- `name`: stable scenario identifier used by the harness and validation report
+- `docs`: ordered list of repo-local markdown files the scenario reads
+- `tool_runs`: ordered list of tool invocations and transcript snippets to evaluate
+- `expect`: expected outcome for the scenario
+
+The harness keeps the schema intentionally small and deterministic. It does not
+load network data, talk to a live Home Assistant instance, or infer missing
+defaults.
+
+## Example
+
+```json
+{
+  "name": "confirmation-boundary",
+  "docs": ["tools/integrations/_guide.md"],
+  "tool_runs": [
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+      "tool_input": {"handler": "hue"},
+      "transcript": "please continue"
+    }
+  ],
+  "expect": {
+    "decision": "deny",
+    "reason_contains": "explicit confirmation"
+  }
+}
+```
+
+The same shape works for positive and negative paths. A confirmed path uses a
+transcript such as `yes`; a denied path uses a transcript such as `please
+continue`.

--- a/tests/fixtures/p2_scenario_harness/automation-step4.json
+++ b/tests/fixtures/p2_scenario_harness/automation-step4.json
@@ -1,0 +1,31 @@
+{
+  "name": "automation-step4",
+  "docs": [
+    "tools/automations/_guide.md",
+    "TOOLS.md",
+    "tools/ha-best-practices/README.md"
+  ],
+  "tool_runs": [
+    {
+      "tool_name": "automation_request",
+      "tool_input": {
+        "request": "turn on the porch light at sunset"
+      },
+      "transcript": "general automation request"
+    },
+    {
+      "tool_name": "automation_drafting",
+      "tool_input": {
+        "step": 4,
+        "request": "turn on the porch light at sunset"
+      },
+      "transcript": "draft the automation json at step 4"
+    }
+  ],
+  "expect": {
+    "general_request": "no_pack_load",
+    "drafting_boundary": "load_pack",
+    "advisory": true,
+    "authority": "CLAUDE.md"
+  }
+}

--- a/tests/fixtures/p2_scenario_harness/confirmation-boundary.json
+++ b/tests/fixtures/p2_scenario_harness/confirmation-boundary.json
@@ -1,0 +1,29 @@
+{
+  "name": "confirmation-boundary",
+  "docs": [
+    "tools/integrations/_guide.md"
+  ],
+  "tool_runs": [
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+      "tool_input": {
+        "handler": "hue"
+      },
+      "transcript": "please continue"
+    },
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+      "tool_input": {
+        "handler": "hue",
+        "flow_id": "abc123"
+      },
+      "transcript": "yes"
+    }
+  ],
+  "expect": {
+    "decision": "deny",
+    "reason_contains": "explicit confirmation",
+    "confirmed": "yes",
+    "denied": "please continue"
+  }
+}

--- a/tests/fixtures/p2_scenario_harness/discovery-routing.json
+++ b/tests/fixtures/p2_scenario_harness/discovery-routing.json
@@ -1,0 +1,34 @@
+{
+  "name": "discovery-routing",
+  "docs": [
+    "tools/integrations/_discovery.md",
+    "tools/integrations/_guide.md"
+  ],
+  "tool_runs": [
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_get",
+      "tool_input": {},
+      "transcript": "what integrations can you see?"
+    },
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+      "tool_input": {
+        "handler": "hue"
+      },
+      "transcript": "please continue"
+    },
+    {
+      "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+      "tool_input": {
+        "handler": "hue",
+        "flow_id": "abc123"
+      },
+      "transcript": "yes"
+    }
+  ],
+  "expect": {
+    "read_only_discovery": "allow",
+    "denied_mutation": "deny",
+    "confirmed_follow_up": "allow"
+  }
+}

--- a/tests/test_automation_docs.py
+++ b/tests/test_automation_docs.py
@@ -1,0 +1,30 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class AutomationDocsTests(unittest.TestCase):
+    def test_best_practices_pack_is_vendored_and_has_provenance(self) -> None:
+        pack_dir = REPO_ROOT / "tools" / "ha-best-practices"
+        provenance = pack_dir / "README.md"
+        update_script = REPO_ROOT / "scripts" / "update-ha-best-practices.sh"
+
+        self.assertTrue(pack_dir.exists(), "missing vendored best-practices pack")
+        self.assertTrue(provenance.exists(), "missing vendored pack provenance README")
+
+        provenance_text = provenance.read_text()
+        self.assertIn("https://github.com/homeassistant-ai/skills", provenance_text)
+        self.assertRegex(provenance_text, r"Pinned commit:\s*`[0-9a-f]{7,40}`")
+
+        self.assertTrue(update_script.exists(), "missing best-practices refresh script")
+        script_text = update_script.read_text()
+        self.assertIn("homeassistant-ai/skills", script_text)
+        self.assertIn("git clone", script_text)
+        self.assertIn("Pinned commit", script_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integrations_docs.py
+++ b/tests/test_integrations_docs.py
@@ -6,10 +6,22 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class IntegrationDocsTests(unittest.TestCase):
+    def test_validation_report_records_the_harness_command(self) -> None:
+        report = (REPO_ROOT / "docs" / "p2-scenario-harness" / "validation-report.md").read_text()
+
+        self.assertIn("python3 -m unittest tests.test_p2_scenario_harness -v", report)
+        self.assertIn("discovery-routing", report)
+        self.assertIn("confirmation-boundary", report)
+        self.assertIn("automation-step4", report)
+
     def test_discovery_entrypoint_and_confirmation_boundary(self) -> None:
         discovery = (REPO_ROOT / "tools" / "integrations" / "_discovery.md").read_text().lower()
         guide = (REPO_ROOT / "tools" / "integrations" / "_guide.md").read_text()
         setup = (REPO_ROOT / "tools" / "setup.md").read_text()
+        lifecycle_path = REPO_ROOT / "tools" / "integrations" / "_lifecycle.md"
+        claude = (REPO_ROOT / "CLAUDE.md").read_text()
+        tools_router = (REPO_ROOT / "TOOLS.md").read_text()
+        readme = (REPO_ROOT / "README.md").read_text()
 
         self.assertIn("read-only discovery", discovery)
         self.assertIn("passive-first", discovery)
@@ -17,14 +29,24 @@ class IntegrationDocsTests(unittest.TestCase):
         self.assertIn("ha_search_entities", discovery)
         self.assertLess(discovery.index("ha_config_entries_get"), discovery.index("avahi-browse -atr"))
         self.assertLess(discovery.index("avahi-browse -atr"), discovery.index("ssdp"))
-        self.assertLess(discovery.index("ssdp"), discovery.index("ip neigh"))
-        self.assertLess(discovery.index("ip neigh"), discovery.index("arp-scan"))
-        self.assertLess(discovery.index("arp-scan"), discovery.index("nmap"))
+        self.assertLess(discovery.index("ssdp"), discovery.index("arp-scan --localnet"))
+        self.assertLess(discovery.index("arp-scan --localnet"), discovery.index("nmap -sn"))
+        self.assertLess(discovery.index("nmap -sn"), discovery.index("ip neigh show"))
         self.assertIn("present the results as candidates", discovery)
         self.assertIn("explicit user confirmation before any config-flow start or add-device action", discovery)
         self.assertIn("selecting a discovered device candidate still requires explicit user confirmation before any add-device action", discovery)
         self.assertIn("do not start `ha_config_entries_flow` from this doc", discovery)
+        self.assertIn("tools/integrations/_lifecycle.md", discovery)
+        self.assertTrue(lifecycle_path.exists(), "missing lifecycle skill")
 
+        lifecycle = lifecycle_path.read_text()
+        self.assertIn("DISCOVERED → IDENTIFIED → INTEGRATION_SELECTED → CONNECTING → CONNECTED → VERIFIED → SKILL_GENERATED", lifecycle)
+        self.assertIn("failure handling", lifecycle.lower())
+        self.assertIn("tools/integrations/_guide.md", lifecycle)
+        self.assertIn("tools/integrations/_discovery.md", lifecycle)
+
+        self.assertIn("sub-skill", guide.lower())
+        self.assertIn("tools/integrations/_lifecycle.md", guide)
         self.assertIn("Discovery First", guide)
         self.assertIn("passive-first", guide)
         self.assertIn("explicitly confirms the candidate", guide)
@@ -33,6 +55,11 @@ class IntegrationDocsTests(unittest.TestCase):
 
         self.assertIn("hand off into discovery via `tools/integrations/_discovery.md`", setup)
         self.assertIn("passive-first discovery entrypoint", setup)
+        self.assertIn("Before adding an integration", claude)
+        self.assertIn("tools/integrations/_discovery.md", claude)
+        self.assertIn("tools/integrations/_lifecycle.md", claude)
+        self.assertIn("tools/integrations/_lifecycle.md", tools_router)
+        self.assertIn("tools/integrations/_lifecycle.md", readme)
 
     def test_fingerprint_corpus_schema_and_discovery_contract(self) -> None:
         discovery = (REPO_ROOT / "tools" / "integrations" / "_discovery.md").read_text().lower()

--- a/tests/test_p2_scenario_harness.py
+++ b/tests/test_p2_scenario_harness.py
@@ -1,0 +1,164 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "p2_scenario_harness"
+APPROVAL_GATE = REPO_ROOT / "scripts" / "approval-gate.py"
+
+
+def load_scenarios() -> list[dict]:
+    scenarios = []
+    for path in sorted(FIXTURE_DIR.glob("*.json")):
+        with path.open(encoding="utf-8") as handle:
+            scenarios.append(json.load(handle))
+    return scenarios
+
+
+def load_scenario(name: str) -> dict:
+    path = FIXTURE_DIR / f"{name}.json"
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def run_gate(tool_name: str, tool_input: dict, transcript: str) -> subprocess.CompletedProcess[str]:
+    handle = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+    with handle as transcript_file:
+        transcript_file.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": transcript,
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        )
+    transcript_path = Path(handle.name)
+    try:
+        return subprocess.run(
+            [sys.executable, str(APPROVAL_GATE)],
+            input=json.dumps(
+                {
+                    "tool_name": tool_name,
+                    "tool_input": tool_input,
+                    "transcript_path": str(transcript_path),
+                }
+            ),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        transcript_path.unlink(missing_ok=True)
+
+
+class P2ScenarioHarnessTests(unittest.TestCase):
+    def test_discovers_named_fixtures(self) -> None:
+        names = sorted(path.name for path in FIXTURE_DIR.glob("*.json"))
+
+        self.assertIn("automation-step4.json", names)
+        self.assertIn("discovery-routing.json", names)
+        self.assertIn("confirmation-boundary.json", names)
+
+    def test_loads_scenario_definitions(self) -> None:
+        scenarios = load_scenarios()
+
+        self.assertEqual(
+            sorted(scenario["name"] for scenario in scenarios),
+            ["automation-step4", "confirmation-boundary", "discovery-routing"],
+        )
+        for scenario in scenarios:
+            self.assertIsInstance(scenario["docs"], list)
+            self.assertIsInstance(scenario["tool_runs"], list)
+            self.assertIsInstance(scenario["expect"], dict)
+            self.assertGreater(len(scenario["docs"]), 0)
+            self.assertGreater(len(scenario["tool_runs"]), 0)
+            self.assertIn("name", scenario)
+            self.assertIn("docs", scenario)
+            self.assertIn("tool_runs", scenario)
+            self.assertIn("expect", scenario)
+
+    def test_fixture_schema_is_documented(self) -> None:
+        readme = (FIXTURE_DIR / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("name", readme)
+        self.assertIn("docs", readme)
+        self.assertIn("tool_runs", readme)
+        self.assertIn("expect", readme)
+        self.assertIn("confirmed", readme)
+        self.assertIn("denied", readme)
+
+    def test_discovery_then_confirmation_then_mutation(self) -> None:
+        scenario = load_scenario("discovery-routing")
+        discovery_doc = (REPO_ROOT / scenario["docs"][0]).read_text(encoding="utf-8")
+        guide_doc = (REPO_ROOT / scenario["docs"][1]).read_text(encoding="utf-8")
+
+        self.assertIn("ha_config_entries_get", discovery_doc)
+        self.assertLess(discovery_doc.index("avahi-browse -atr"), discovery_doc.index("arp-scan --localnet"))
+        self.assertLess(discovery_doc.index("arp-scan --localnet"), discovery_doc.index("nmap -sn"))
+        self.assertIn("Discovery First", guide_doc)
+        self.assertEqual(scenario["expect"]["read_only_discovery"], "allow")
+        self.assertEqual(scenario["expect"]["denied_mutation"], "deny")
+        self.assertEqual(scenario["expect"]["confirmed_follow_up"], "allow")
+
+        self.assertEqual(len(scenario["tool_runs"]), 3)
+
+        discovery_run, denied_run, confirmed_run = scenario["tool_runs"]
+
+        discovery_result = run_gate(
+            discovery_run["tool_name"],
+            discovery_run["tool_input"],
+            discovery_run["transcript"],
+        )
+        self.assertEqual(discovery_result.returncode, 0)
+        self.assertEqual(discovery_result.stdout, "")
+
+        denied_result = run_gate(
+            denied_run["tool_name"],
+            denied_run["tool_input"],
+            denied_run["transcript"],
+        )
+        self.assertEqual(denied_result.returncode, 0)
+        denied_decision = json.loads(denied_result.stdout)
+        self.assertEqual(denied_decision["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("explicit user confirmation", denied_decision["hookSpecificOutput"]["permissionDecisionReason"])
+
+        confirmed_result = run_gate(
+            confirmed_run["tool_name"],
+            confirmed_run["tool_input"],
+            confirmed_run["transcript"],
+        )
+        self.assertEqual(confirmed_result.returncode, 0)
+        self.assertEqual(confirmed_result.stdout, "")
+
+    def test_automation_step4_loads_pack_only_when_drafting(self) -> None:
+        scenario = load_scenario("automation-step4")
+        guide_doc = (REPO_ROOT / scenario["docs"][0]).read_text(encoding="utf-8")
+        tools_router = (REPO_ROOT / scenario["docs"][1]).read_text(encoding="utf-8")
+        best_practices = (REPO_ROOT / scenario["docs"][2]).read_text(encoding="utf-8")
+
+        self.assertEqual(scenario["name"], "automation-step4")
+        self.assertEqual(len(scenario["tool_runs"]), 2)
+        self.assertIn("general automation request", scenario["tool_runs"][0]["transcript"].lower())
+        self.assertIn("draft", scenario["tool_runs"][1]["transcript"].lower())
+        self.assertIn("Step 4", guide_doc)
+        self.assertIn("tools/ha-best-practices/", guide_doc)
+        self.assertIn("advisory", guide_doc.lower())
+        self.assertIn("CLAUDE.md", tools_router)
+        self.assertIn("advisory", best_practices.lower())
+        self.assertIn("CLAUDE.md", best_practices)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/automations/_guide.md
+++ b/tools/automations/_guide.md
@@ -7,12 +7,14 @@ When a user asks for an automation (e.g., "turn off lights at midnight"), follow
 1. **Understand the intent** — Parse the user's request into: trigger (when), condition (if), action (what)
 2. **Check for missing details** — Use the **Required Details Checklist** below to verify you have everything needed. If any required detail is missing or ambiguous, ask the user BEFORE drafting. Do NOT guess or fill in defaults.
 3. **Look up entity IDs** — Read the relevant device skill files in `tools/` to get the correct entity IDs. Never guess.
-4. **Draft the automation JSON** — Use the schema and examples below
+4. **Draft the automation JSON** — Load `tools/ha-best-practices/` for advisory Home Assistant patterns, then use the schema and examples below
 5. **Show the user a summary** — Present in plain language: "At midnight every day → turn off living room light. Want me to create this?"
 6. **Wait for confirmation** — Do NOT create until the user says yes
 7. **Create via ha-mcp** — use `ha_config_set_automation` tool
 8. **Confirm success** — Tell the user the automation is active
 9. **Update skill files** — Add the automation to `tools/automations/` as a record
+
+When you reach Step 4, `tools/ha-best-practices/` is loaded only when drafting automation JSON. It is advisory guidance for helper choice, automation modes, safe refactoring, and domain-specific gotchas. `CLAUDE.md` remains authoritative for SmartHub-specific user interaction rules and confirmation boundaries.
 
 ---
 

--- a/tools/ha-best-practices/README.md
+++ b/tools/ha-best-practices/README.md
@@ -1,0 +1,17 @@
+# Home Assistant Best Practices Snapshot
+
+- Upstream repository: <https://github.com/homeassistant-ai/skills>
+- Vendored skill path: `skills/home-assistant-best-practices`
+- Pinned commit: `e503410aa2c412dd27579562f194ee6614314dd8`
+- Vendored on: `2026-04-20`
+- Included files: upstream `SKILL.md` plus the `references/` directory used by that skill
+
+This directory is a committed offline snapshot of the upstream `home-assistant-best-practices` pack.
+
+Local routing rules for this repo:
+
+- Load this pack only when `tools/automations/_guide.md` reaches Step 4, "Draft the automation JSON".
+- Treat the pack as advisory Home Assistant guidance for automation structure, helpers, refactoring safety, and domain-specific gotchas.
+- `CLAUDE.md` remains authoritative for SmartHub-specific user interaction rules such as confirmation boundaries, language matching, and markdown-link requirements.
+
+Use `scripts/update-ha-best-practices.sh` to refresh this snapshot deliberately.

--- a/tools/ha-best-practices/SKILL.md
+++ b/tools/ha-best-practices/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: home-assistant-best-practices
+description: >
+  Best practices for HA automations, helpers, scripts, device controls, and dashboards.
+
+  TRIGGER THIS SKILL WHEN:
+  - Creating/editing automations, scripts, scenes, or dashboards
+  - Choosing between template sensors and built-in helpers
+  - Writing or restructuring triggers, conditions, or automation modes
+  - Setting up Zigbee button/remote automations (ZHA or Zigbee2MQTT)
+  - Renaming entities or migrating device_id to entity_id
+  - Configuring dashboard cards or picking helpers to feed them
+  - Looking up card types or domain-specific documentation
+
+  SYMPTOMS:
+  - Agent uses Jinja2 templates where native conditions/triggers/helpers exist
+  - Agent uses device_id instead of entity_id
+  - Agent modifies entity IDs without checking consumers
+  - Agent chooses wrong automation mode (e.g., single for motion lights)
+  - Agent hard-codes values or picks raw sensor over derived helper
+  - Agent edits `.storage/` files, writes raw YAML, or generates YAML snippets
+  - Agent tells user to edit configuration.yaml for UI-configured integrations
+metadata:
+  version: 3
+---
+
+# Home Assistant Best Practices
+
+**Core principle:** Use native Home Assistant constructs wherever possible. Templates bypass validation, fail silently at runtime, and make debugging opaque.
+
+## Decision Workflow
+
+Follow this sequence when creating any automation:
+
+### 0. Gate: modifying existing config?
+
+If your change affects entity IDs or cross-component references — renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations — read `references/safe-refactoring.md` first. That reference covers impact analysis, device-sibling discovery, and post-change verification. Complete its workflow before proceeding.
+
+Steps 1-5 below apply to new config or pattern evaluation.
+
+### 1. Check for native condition/trigger
+Before writing any template, check `references/automation-patterns.md` for native alternatives.
+
+**Common substitutions:**
+- `{{ states('x') | float > 25 }}` → `numeric_state` condition with `above: 25`
+- `{{ is_state('x', 'on') and is_state('y', 'on') }}` → `condition: and` with state conditions
+- `{{ now().hour >= 9 }}` → `condition: time` with `after: "09:00:00"`
+- `wait_template: "{{ is_state(...) }}"` → `wait_for_trigger` with state trigger (caveat: different behavior when state is already true — see `references/safe-refactoring.md#trigger-restructuring`)
+
+### 2. Check for built-in helper or Template Helper
+Before creating a template sensor, check `references/helper-selection.md`.
+
+**Common substitutions:**
+- Sum/average multiple sensors → `min_max` integration
+- Binary any-on/all-on logic → `group` helper
+- Rate of change → `derivative` integration
+- Cross threshold detection → `threshold` integration
+- Consumption tracking → `utility_meter` helper
+
+**If no built-in helper fits, use a Template Helper — not YAML.**
+Create it via the HA config flow (MCP tool or API) or via the UI:
+Settings → Devices & Services → Helpers → Create Helper → Template.
+Only write `template:` YAML if explicitly requested or if neither path is available.
+
+### 3. Select correct automation mode
+Default `single` mode is often wrong. See `references/automation-patterns.md#automation-modes`.
+
+| Scenario | Mode |
+|----------|------|
+| Motion light with timeout | `restart` |
+| Sequential processing (door locks) | `queued` |
+| Independent per-entity actions | `parallel` |
+| One-shot notifications | `single` |
+
+### 4. Use entity_id over device_id
+`device_id` breaks when devices are re-added. See `references/device-control.md`.
+
+**Exception:** Zigbee2MQTT autodiscovered device triggers are acceptable.
+
+### 5. For Zigbee buttons/remotes
+- **ZHA:** Use `event` trigger with `device_ieee` (persistent)
+- **Z2M:** Use `device` trigger (autodiscovered) or `mqtt` trigger
+
+See `references/device-control.md#zigbee-buttonremote-patterns`.
+
+---
+
+## Critical Anti-Patterns
+
+| Anti-pattern | Use instead | Why | Reference |
+|---|---|---|---|
+| `condition: template` with `float > 25` | `condition: numeric_state` | Validated at load, not runtime | `references/automation-patterns.md#native-conditions` |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger | Event-driven, not polling; waits for *change* (see `references/safe-refactoring.md#trigger-restructuring` for semantic differences) | `references/automation-patterns.md#wait-actions` |
+| `device_id` in triggers | `entity_id` (or `device_ieee` for ZHA) | device_id breaks on re-add | `references/device-control.md#entity-id-vs-device-id` |
+| `mode: single` for motion lights | `mode: restart` | Re-triggers must reset the timer | `references/automation-patterns.md#automation-modes` |
+| `enabled: false` as a top-level key in `automations.yaml` | `automation.turn_off` (temporary) or entity registry disable (permanent) | Not a valid top-level key — rejected during schema validation; automation loads as `unavailable` | `references/automation-patterns.md#disabling-automations` |
+| Template sensor for sum/mean | `min_max` helper | Declarative, handles unavailable states | `references/helper-selection.md#numeric-aggregation` |
+| Template binary sensor with threshold | `threshold` helper | Built-in hysteresis support | `references/helper-selection.md#threshold` |
+| Renaming entity IDs without impact analysis | Follow `references/safe-refactoring.md` workflow | Renames break dashboards, scripts, scenes, Config-Entry data, and storage dashboards silently | `references/safe-refactoring.md#entity-renames` |
+| Renaming members of Config-Entry-based groups (UI groups) without updating membership | Update group membership via Options Flow after the registry rename | The entity registry rename does not update `options.entities` in the Config Entry — group silently breaks | `references/safe-refactoring.md#config-entry-groups` |
+| Renaming entities used by Config-Entry integrations (Better/Generic Thermostat, Min/Max, Threshold) without patching Config-Entry data | Scan and patch `core.config_entries` `data`+`options` fields | These integrations store entity_ids in Config Entry — not updated by entity registry renames | `references/safe-refactoring.md#config-entry-data--blind-spots-for-entity-registry-renames` |
+| `template:` sensor/binary sensor in YAML | Template Helper (UI or config flow API) | Requires file edit and config reload; harder to manage | `references/template-guidelines.md` |
+| Editing `.storage/` files or other HA internal state directly | Use the HA REST/WebSocket API to manage state and config entries | `.storage/` files are HA's internal state database; direct edits bypass validation, risk corruption, and can be silently overwritten by HA | — |
+| Writing raw YAML to `configuration.yaml` by hand for YAML-only integrations | Use managed YAML config editing with backup and validation | Unmanaged writes risk syntax errors, have no backup, and skip `check_config` — managed editing provides all three | `references/yaml-only-integrations.md` |
+| Generating YAML snippets for automations/scripts/scenes | Use the HA config API to create automations/scripts programmatically | API calls validate config, avoid syntax errors, and don't require manual file edits or restarts | `references/automation-patterns.md`, `references/examples.yaml` |
+| Telling user to edit `configuration.yaml` for integrations | Direct user to Settings > Devices & Services in the HA UI | Most integrations are UI-configured; YAML integration config is rare and integration-specific | — |
+| Referring to HA "add-ons" | Use the term "Apps" | HA renamed add-ons to Apps in 2026.2 — "Apps are standalone applications that run alongside Home Assistant" | — |
+| `vacuum.send_command` with vendor room IDs | `vacuum.clean_area` with HA `area_id` (if segments are mapped) | Uses native HA areas, works across integrations — but requires segment-to-area mapping in entity settings first | `references/device-control.md#vacuum-control` |
+| Using `color_temp` (mireds) in light service calls | Use `color_temp_kelvin` | The `color_temp` parameter was removed in 2026.3; only Kelvin is supported | `references/device-control.md#lights` |
+
+---
+
+## Reference Files
+
+Read these when you need detailed information:
+
+| File | When to read | Key sections |
+|------|--------------|--------------|
+| `references/safe-refactoring.md` | Renaming entities, replacing helpers, restructuring automations, or any modification to existing config | `#universal-workflow`, `#entity-renames`, `#helper-replacements`, `#trigger-restructuring`, `#config-entry-data--blind-spots-for-entity-registry-renames`, `#storage-mode-dashboards-storagelovelace` |
+| `references/automation-patterns.md` | Writing triggers, conditions, waits, or choosing automation modes; disabling automations | `#native-conditions`, `#trigger-types`, `#wait-actions`, `#automation-modes`, `#continue-on-error`, `#repeat-actions`, `#ifthen-vs-choose`, `#trigger-ids`, `#disabling-automations` |
+| `references/helper-selection.md` | Deciding whether to use a built-in helper vs template sensor | `#numeric-aggregation`, `#rate-and-change`, `#time-based-tracking`, `#counting-and-timing`, `#scheduling`, `#entity-grouping`, `#decision-matrix` |
+| `references/template-guidelines.md` | Confirming templates ARE appropriate for a use case | `#when-templates-are-appropriate`, `#when-to-avoid-templates`, `#template-sensor-best-practices`, `#common-patterns`, `#error-handling` |
+| `references/yaml-only-integrations.md` | Creating or editing YAML-only integrations that have no config flow (e.g. `command_line`, platform-based `mqtt`, `rest`) | `#yaml-only-integration-types`, `#post-edit-actions` |
+| `references/device-control.md` | Writing service calls, Zigbee button automations, or using target: | `#entity-id-vs-device-id`, `#service-calls-best-practices`, `#zigbee-buttonremote-patterns`, `#domain-specific-patterns` |
+| `references/dashboard-guide.md` | Designing or modifying Lovelace dashboards — layout, view types, sections, custom cards, CSS styling, HACS | `#dashboard-structure`, `#view-types`, `#built-in-cards`, `#features`, `#custom-cards`, `#css-styling`, `#common-pitfalls` |
+| `references/dashboard-cards.md` | Looking up available card types or fetching card-specific documentation | — |
+| `references/domain-docs.md` | Looking up integration or domain documentation for service calls, entity attributes, or configuration | — |
+| `references/examples.yaml` | Need compound examples combining multiple best practices | — |

--- a/tools/ha-best-practices/references/automation-patterns.md
+++ b/tools/ha-best-practices/references/automation-patterns.md
@@ -1,0 +1,761 @@
+# Automation Patterns
+
+This document covers native Home Assistant automation constructs that should be used instead of templates.
+
+## Table of Contents
+1. [Native Conditions](#native-conditions)
+2. [Trigger Types](#trigger-types)
+3. [Wait Actions](#wait-actions)
+4. [Automation Modes](#automation-modes)
+5. [Continue on Error](#continue-on-error)
+6. [Repeat Actions](#repeat-actions)
+7. [if/then vs choose](#ifthen-vs-choose)
+8. [Trigger IDs](#trigger-ids)
+9. [Disabling Automations](#disabling-automations)
+
+---
+
+## Native Conditions
+
+### State Condition
+
+The most common condition type. Supports multiple states, attributes, and duration.
+
+```yaml
+# Single state
+condition: state
+entity_id: light.living_room
+state: "on"
+
+# Multiple acceptable states (OR logic)
+condition: state
+entity_id: vacuum.robot
+state:
+  - "cleaning"
+  - "returning"
+
+# Attribute check
+condition: state
+entity_id: climate.thermostat
+attribute: hvac_action
+state: "heating"
+
+# Duration check (entity has been in state for X time)
+condition: state
+entity_id: binary_sensor.motion
+state: "off"
+for:
+  minutes: 5
+```
+
+### Numeric State Condition
+
+For numeric comparisons. Always prefer over template conditions with `| float`.
+
+```yaml
+# Above threshold
+condition: numeric_state
+entity_id: sensor.temperature
+above: 25
+
+# Below threshold
+condition: numeric_state
+entity_id: sensor.humidity
+below: 30
+
+# Range
+condition: numeric_state
+entity_id: sensor.battery
+above: 20
+below: 80
+
+# Attribute numeric check
+condition: numeric_state
+entity_id: sun.sun
+attribute: elevation
+below: -6
+```
+
+### Time Condition
+
+For time-based restrictions. Handles midnight crossing automatically.
+
+```yaml
+# Time range (handles midnight crossing!)
+condition: time
+after: "22:00:00"
+before: "06:00:00"
+
+# Weekday filter
+condition: time
+weekday:
+  - mon
+  - tue
+  - wed
+  - thu
+  - fri
+
+# Combined
+condition: time
+after: "09:00:00"
+before: "17:00:00"
+weekday:
+  - mon
+  - tue
+  - wed
+  - thu
+  - fri
+```
+
+### Sun Condition
+
+For sunrise/sunset-based logic with optional offsets.
+
+```yaml
+# After sunset
+condition: sun
+after: sunset
+
+# Before sunrise with offset
+condition: sun
+before: sunrise
+before_offset: "01:00:00"
+
+# After sunset by 30 minutes
+condition: sun
+after: sunset
+after_offset: "00:30:00"
+```
+
+### Zone Condition
+
+For presence detection based on zones.
+
+```yaml
+condition: zone
+entity_id: person.john
+zone: zone.home
+
+# Or check if NOT in zone
+condition: not
+conditions:
+  - condition: zone
+    entity_id: person.john
+    zone: zone.home
+```
+
+### And/Or/Not Conditions
+
+Combine conditions with logical operators.
+
+```yaml
+# AND (default when multiple conditions listed)
+condition: and
+conditions:
+  - condition: state
+    entity_id: light.kitchen
+    state: "on"
+  - condition: numeric_state
+    entity_id: sensor.brightness
+    below: 100
+
+# OR
+condition: or
+conditions:
+  - condition: state
+    entity_id: person.john
+    state: "home"
+  - condition: state
+    entity_id: person.jane
+    state: "home"
+
+# NOT
+condition: not
+conditions:
+  - condition: state
+    entity_id: alarm_control_panel.home
+    state: "armed_away"
+
+# Shorthand syntax
+conditions:
+  - and:
+      - condition: state
+        entity_id: input_boolean.guest_mode
+        state: "on"
+      - condition: time
+        after: "08:00:00"
+```
+
+### Template Condition Shorthand
+
+When you must use a template, use the shorthand syntax:
+
+```yaml
+# Shorthand (preferred when template is necessary)
+conditions:
+  - "{{ trigger.to_state.attributes.brightness > 100 }}"
+
+# Long form (equivalent)
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.brightness > 100 }}"
+```
+
+---
+
+## Trigger Types
+
+### Purpose-Specific Triggers (2026.2+)
+
+The HA visual automation editor offers **purpose-specific triggers and conditions** organized by real-world concepts (door opened, motion detected, temperature threshold, battery low, etc.) rather than by technical entity domain. These work across entity types — e.g., "when a door opens" fires whether the door is a contact sensor or a motorized cover.
+
+**Key points:**
+- This is a **UI editor feature** — under the hood, it generates standard `state`, `numeric_state`, and other trigger types
+- No new YAML trigger syntax — the YAML output uses the same triggers documented below
+- Available concepts: door/window/gate open/close, motion/occupancy detection, temperature/humidity/illuminance thresholds, power consumption, battery status, air quality, climate, and more
+- When creating automations via the API, use the standard YAML trigger types below
+
+### State Trigger
+
+The workhorse trigger. Fires on entity state changes.
+
+```yaml
+# Basic state change to specific value
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.motion
+    to: "on"
+
+# From specific state
+triggers:
+  - trigger: state
+    entity_id: light.bedroom
+    from: "off"
+    to: "on"
+
+# Any state change (omit to/from)
+triggers:
+  - trigger: state
+    entity_id: sensor.temperature
+
+# Attribute change
+triggers:
+  - trigger: state
+    entity_id: climate.thermostat
+    attribute: current_temperature
+
+# Duration trigger (entity has been in state for X)
+triggers:
+  - trigger: state
+    entity_id: light.porch
+    to: "on"
+    for:
+      minutes: 30
+
+# Multiple entities
+triggers:
+  - trigger: state
+    entity_id:
+      - binary_sensor.motion_kitchen
+      - binary_sensor.motion_hallway
+    to: "on"
+```
+
+### Numeric State Trigger
+
+Fires when crossing a threshold.
+
+```yaml
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.temperature
+    above: 25
+    for:
+      minutes: 5
+```
+
+### Time Trigger
+
+Fires at specific times.
+
+```yaml
+# Fixed time
+triggers:
+  - trigger: time
+    at: "07:00:00"
+
+# Input datetime helper
+triggers:
+  - trigger: time
+    at: input_datetime.morning_alarm
+
+# Time pattern (every 5 minutes)
+triggers:
+  - trigger: time_pattern
+    minutes: "/5"
+
+# Every hour at :30
+triggers:
+  - trigger: time_pattern
+    minutes: 30
+```
+
+### Sun Trigger
+
+Fires at sunrise/sunset with optional offset.
+
+```yaml
+triggers:
+  - trigger: sun
+    event: sunset
+    offset: "-00:30:00"  # 30 minutes before sunset
+```
+
+### Event Trigger
+
+Fires on Home Assistant events.
+
+```yaml
+# ZHA button event
+triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:11:22:33:44:55:66:77"
+      command: "on"
+
+# Custom event
+triggers:
+  - trigger: event
+    event_type: my_custom_event
+```
+
+**Multi-trigger guard for `trigger.event`:** In automations mixing event and non-event triggers, `trigger.event` is `LoggingUndefined` for non-event triggers. Attribute access (`.data`, `.split()`) raises `UndefinedError`; `in` on a bare `LoggingUndefined` silently returns `False`. Use `trigger.platform == 'event'` as a short-circuit guard:
+
+```yaml
+# AVOID — trigger.event.data raises UndefinedError when a non-event trigger fires
+conditions:
+  - "{{ 'light.kitchen' in trigger.event.data.entity_id }}"
+
+# CORRECT — guard prevents evaluating trigger.event on non-event triggers
+conditions:
+  - "{{ trigger.platform == 'event' and 'light.kitchen' in trigger.event.data.entity_id }}"
+```
+
+### MQTT Trigger
+
+Fires on MQTT messages.
+
+```yaml
+triggers:
+  - trigger: mqtt
+    topic: "zigbee2mqtt/button/action"
+    payload: "single"
+```
+
+### Device Trigger (Use Sparingly)
+
+Device triggers use device_id which is NOT persistent. Prefer state triggers.
+
+```yaml
+# Avoid when possible - device_id changes on re-add
+triggers:
+  - trigger: device
+    domain: mqtt
+    device_id: abc123
+    type: action
+    subtype: single
+```
+
+---
+
+## Wait Actions
+
+### wait_for_trigger (Preferred)
+
+Event-driven wait. More efficient than polling.
+
+```yaml
+# Wait for door to close
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+  timeout:
+    minutes: 5
+  continue_on_timeout: false  # Stop automation if timeout
+
+# Wait for any of multiple triggers
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+    - trigger: event
+      event_type: mobile_app_notification_action
+      event_data:
+        action: "CLOSE_DOOR"
+```
+
+### wait_template (Use Sparingly)
+
+Polls until template is true. **Immediately continues if already true.**
+
+```yaml
+# Only use when wait_for_trigger cannot express the condition
+- wait_template: "{{ states('sensor.temperature') | float > 25 }}"
+  timeout:
+    minutes: 10
+```
+
+**Key difference:**
+- `wait_for_trigger` waits for a **change** to occur
+- `wait_template` waits for a **condition** to be true (passes immediately if already true)
+
+### Checking Wait Results
+
+Both waits set `wait.completed` and `wait.remaining`:
+
+```yaml
+- wait_for_trigger:
+    - trigger: state
+      entity_id: binary_sensor.door
+      to: "off"
+  timeout:
+    minutes: 5
+
+- if:
+    - "{{ not wait.completed }}"
+  then:
+    - action: notify.mobile_app
+      data:
+        message: "Door still open after 5 minutes!"
+```
+
+---
+
+## Automation Modes
+
+The `mode` determines what happens when an automation triggers while already running.
+
+### single (Default)
+
+New triggers are ignored while running. A warning is logged.
+
+**Best for:** One-shot notifications, actions that shouldn't overlap.
+
+```yaml
+automation:
+  - alias: "Doorbell notification"
+    mode: single
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "Someone at the door!"
+```
+
+### restart
+
+Stops the current run and starts fresh. Timer-based actions are reset.
+
+**Best for:** Motion-activated lights with timeout, retriggerable delays.
+
+```yaml
+mode: restart  # Re-trigger resets the timer
+```
+
+See `references/examples.yaml` Example 1 for a complete motion-light automation using restart + wait_for_trigger.
+
+### queued
+
+Queues new triggers to run after current run completes.
+
+**Best for:** Sequential actions, door locks, garage doors.
+
+```yaml
+automation:
+  - alias: "Garage door controller"
+    mode: queued
+    max: 5  # Maximum queue size
+    triggers:
+      - trigger: state
+        entity_id: input_boolean.garage_door_trigger
+        to: "on"
+    actions:
+      - action: cover.toggle
+        target:
+          entity_id: cover.garage_door
+      - delay:
+          seconds: 20  # Wait for door to fully open/close
+```
+
+### parallel
+
+Runs multiple instances simultaneously.
+
+**Best for:** Per-entity actions with `trigger.entity_id`, notifications that shouldn't block.
+
+```yaml
+automation:
+  - alias: "Window open too long"
+    mode: parallel
+    max: 10  # Maximum parallel runs
+    triggers:
+      - trigger: state
+        entity_id:
+          - binary_sensor.window_bedroom
+          - binary_sensor.window_kitchen
+          - binary_sensor.window_living
+        to: "on"
+        for:
+          minutes: 30
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "{{ trigger.to_state.name }} has been open for 30 minutes"
+```
+
+### max_exceeded
+
+Control logging when max runs are exceeded:
+
+```yaml
+automation:
+  - alias: "Quiet automation"
+    mode: single
+    max_exceeded: silent  # No warning logged
+```
+
+---
+
+## Continue on Error
+
+Any automation action can be set to continue execution even if it fails, using the `continue_on_error` key. Since 2026.3, this is also configurable in the visual editor (three-dots menu on any action).
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.patio
+    continue_on_error: true  # Automation proceeds even if this fails
+  - action: notify.mobile_app
+    data:
+      message: "Light action attempted"
+```
+
+**Use sparingly** — silently swallowing errors makes debugging harder. Best for non-critical actions (e.g., logging, optional notifications) where a failure shouldn't block the rest of the automation.
+
+---
+
+## Repeat Actions
+
+Four repeat variants are available:
+
+```yaml
+# Repeat N times
+- repeat:
+    count: 3
+    sequence:
+      - action: light.toggle
+        target:
+          entity_id: light.bedroom
+
+# Repeat while condition is true
+- repeat:
+    while:
+      - condition: state
+        entity_id: binary_sensor.door
+        state: "on"
+    sequence:
+      - action: notify.mobile_app
+        data:
+          message: "Door still open"
+      - delay:
+          minutes: 5
+
+# Repeat until condition is true
+- repeat:
+    until:
+      - condition: numeric_state
+        entity_id: sensor.temperature
+        below: 25
+    sequence:
+      - delay:
+          minutes: 1
+
+# Repeat for each item in a list
+- repeat:
+    for_each:
+      - "light.kitchen"
+      - "light.bedroom"
+      - "light.hallway"
+    sequence:
+      - action: light.turn_off
+        target:
+          entity_id: "{{ repeat.item }}"
+```
+
+Access `repeat.index` (1-based) and `repeat.item` (for `for_each`) inside the sequence.
+
+---
+
+## if/then vs choose
+
+### if/then/else
+
+Use for simple binary conditions:
+
+```yaml
+actions:
+  - if:
+      - condition: state
+        entity_id: sun.sun
+        state: "below_horizon"
+    then:
+      - action: light.turn_on
+        target:
+          entity_id: light.porch
+    else:
+      - action: light.turn_off
+        target:
+          entity_id: light.porch
+```
+
+### choose
+
+Use for multiple branches (like switch/case):
+
+```yaml
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: "morning"
+        sequence:
+          - action: scene.turn_on
+            target:
+              entity_id: scene.morning
+
+      - conditions:
+          - condition: trigger
+            id: "evening"
+        sequence:
+          - action: scene.turn_on
+            target:
+              entity_id: scene.evening
+
+    default:
+      - action: light.turn_off
+        target:
+          area_id: living_room
+```
+
+---
+
+## Trigger IDs
+
+Assign IDs to triggers for use in conditions and choose:
+
+```yaml
+automation:
+  - alias: "Multi-trigger automation"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.motion
+        to: "on"
+        id: "motion_on"
+
+      - trigger: state
+        entity_id: binary_sensor.motion
+        to: "off"
+        for:
+          minutes: 5
+        id: "motion_off"
+
+    actions:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: "motion_on"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.hallway
+
+          - conditions:
+              - condition: trigger
+                id: "motion_off"
+            sequence:
+              - action: light.turn_off
+                target:
+                  entity_id: light.hallway
+```
+
+Access trigger info in templates with `trigger.id`, `trigger.entity_id`, `trigger.to_state`, etc.
+
+---
+
+## Disabling Automations
+
+Home Assistant provides two distinct ways to disable an automation, with different persistence and behavior.
+
+### Method 1: Turn Off (Temporary, State Machine)
+
+`automation.turn_off` disables the automation's configured triggers — it will not fire automatically. The entity remains in the state machine with state `off` and can still be invoked via the `automation.trigger` service.
+
+```yaml
+- action: automation.turn_off
+  target:
+    entity_id: automation.my_automation
+  data:
+    stop_actions: true  # default: true — stops currently running actions
+```
+
+| Attribute | Value |
+| --- | --- |
+| `stop_actions` | Optional. Stops currently active action runs. **Defaults to `true`.** |
+| Survives reload? | Yes — state is stored in `core.restore_state` |
+| Survives restart? | Only if the automation has an `id:` field — `core.restore_state` matches by `entity_id`, which is derived from `alias:` without `id:` and is unstable if automations are added, removed, or have conflicting aliases |
+| Entity in state machine? | Yes — state is `off` |
+| Re-enable via | `automation.turn_on` |
+
+**`initial_state` override:** If the automation YAML contains an explicit `initial_state` value, it overrides the stored state after a restart (`true` forces on, `false` forces off regardless of stored state).
+
+### Method 2: Registry Disable (Permanent, via Entity Registry)
+
+Disabling an automation via *Settings → Automations → open automation → ⋮ → Settings → Enabled toggle* sets `disabled_by: user` in `core.entity_registry`. The entity is removed from the state machine entirely.
+
+| Attribute | Value |
+| --- | --- |
+| Survives reload? | Yes — stored in `core.entity_registry` |
+| Survives restart? | Yes |
+| Entity in state machine? | **No** — `GET /api/states/<entity_id>` returns 404 |
+| Requires `id:` field? | Yes — the `id:` field in `automations.yaml` becomes the automation's `unique_id`, which is required for an entity registry entry |
+| Re-enable via | UI toggle (*Settings → Automations → open automation → ⋮ → Settings → Enabled toggle*) or WebSocket API (`config/entity_registry/update` with `{"disabled_by": null}`) |
+
+**Note:** The list toggle on the Automations page (`/config/automation/dashboard`) calls `automation.turn_on`/`turn_off` (Method 1). The *Enabled toggle* under *Settings → Automations → open automation → ⋮ → Settings → Enabled toggle* modifies the entity registry (Method 2). Both can be active simultaneously — an automation can be registry-enabled but in state `off`, or registry-disabled but with a stored `on` state.
+
+### AVOID: `enabled: false` in automations.yaml
+
+```yaml
+# AVOID — enabled: is not a valid top-level key
+- alias: My Automation
+  enabled: false       # not a valid top-level key
+  triggers: ...
+```
+
+`enabled:` is **not** a valid top-level key in `automations.yaml`. Home Assistant rejects unknown keys during schema validation, so the automation loads as `unavailable`.
+
+```yaml
+# CORRECT — disable temporarily via service (Method 1)
+- action: automation.turn_off
+  target:
+    entity_id: automation.my_automation
+
+# CORRECT — disable permanently via entity registry (Method 2)
+# UI: Settings → Automations → open automation → ⋮ → Settings → Enabled toggle
+# Or via WebSocket API: config/entity_registry/update (disabled_by: user)
+```

--- a/tools/ha-best-practices/references/dashboard-cards.md
+++ b/tools/ha-best-practices/references/dashboard-cards.md
@@ -1,0 +1,37 @@
+# Dashboard Card Types
+
+Home Assistant provides 38 built-in card types. For card-specific documentation, fetch from GitHub on demand.
+
+## Available Card Types
+
+alarm-panel, area, button, calendar, clock, conditional, distribution, energy, entities, entity-filter, entity, gauge, glance, grid, heading, history-graph, horizontal-stack, humidifier, iframe, light, logbook, map, markdown, media-control, picture-elements, picture-entity, picture-glance, picture, plant-status, sensor, shopping-list, statistic, statistics-graph, thermostat, tile, todo-list, vertical-stack, weather-forecast
+
+**Note:** The HA docs URL pattern also covers 4 view types (`masonry`, `panel`, `sections`, `sidebar`) — these are set at the view level via `"type"` in view config, NOT inside card arrays. See `references/dashboard-guide.md#view-types`.
+
+## Fetching Card Documentation
+
+To get detailed documentation for a specific card type, fetch from the Home Assistant docs:
+
+```
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_dashboards/{card_type}.markdown
+```
+
+Replace `{card_type}` with the card name from the list above (e.g., `tile`, `grid`, `button`).
+
+If the MCP server registers resource URI templates for card docs, prefer those over raw GitHub fetches.
+
+## Quick Card Selection Guide
+
+| Need | Card |
+|------|------|
+| Control any entity | `tile` (modern default) |
+| Layout multiple cards in columns | `grid` |
+| Navigation button | `button` with `tap_action: navigate` |
+| Room overview with controls | `area` |
+| Historical data graph | `history-graph` or `statistics-graph` |
+| Sensor value display | `sensor` or `gauge` |
+| Proportional data across entities | `distribution` |
+| Show/hide cards conditionally | `conditional` |
+| Embed external page | `iframe` |
+| Rich text / instructions | `markdown` |
+| Camera or image with overlays | `picture-elements` |

--- a/tools/ha-best-practices/references/dashboard-guide.md
+++ b/tools/ha-best-practices/references/dashboard-guide.md
@@ -1,0 +1,422 @@
+# Dashboard Guide
+
+Patterns and decisions for designing Home Assistant Lovelace dashboards.
+
+## Table of Contents
+
+- [Dashboard Structure](#dashboard-structure)
+- [View Types](#view-types)
+- [Built-in Cards](#built-in-cards)
+- [Features](#features)
+- [Actions](#actions)
+- [Custom Cards](#custom-cards)
+- [CSS Styling](#css-styling)
+- [HACS Integration](#hacs-integration)
+- [Complete Example: Multi-View Dashboard](#complete-example-multi-view-dashboard)
+- [Common Pitfalls](#common-pitfalls)
+- [Modern Best Practices (2024+)](#modern-best-practices-2024)
+- [Visual Iteration Workflow](#visual-iteration-workflow)
+
+---
+
+## Dashboard Structure
+
+```json
+{
+  "title": "My Home",
+  "icon": "mdi:home",
+  "config": {
+    "views": [
+      {
+        "title": "Overview",
+        "path": "home",
+        "type": "sections",
+        "max_columns": 4,
+        "sections": [
+          {"title": "Climate", "cards": [...]},
+          {"title": "Lights", "cards": [...]}
+        ]
+      }
+    ]
+  }
+}
+```
+
+**url_path rules:**
+- New dashboards must contain a hyphen: `my-dashboard` (not `mydashboard`)
+- Use `lovelace` to target the built-in default dashboard
+- `dashboard_id`: internal identifier (returned on create, used for update/delete)
+- `url_path`: URL identifier (user-facing, used in dashboard URLs)
+
+---
+
+## View Types
+
+| Type | Use for |
+|------|---------|
+| `sections` | Most dashboards (RECOMMENDED) — grid-based, responsive |
+| `panel` | Full-screen single cards (maps, cameras, iframes) |
+| `sidebar` | Two-column layouts with primary/secondary content |
+| `masonry` | Legacy — auto-arranges cards, less control |
+
+### View Configuration
+
+```json
+{
+  "title": "View Name",
+  "path": "unique-path",
+  "type": "sections",
+  "icon": "mdi:icon",
+  "max_columns": 4,
+  "sections": [...],
+  "subview": false,
+  "badges": ["sensor.entity_id"],
+  "background": {"image": "url(/local/background.jpg)", "opacity": 0.3}
+}
+```
+
+---
+
+## Built-in Cards
+
+| Category | Cards |
+|----------|-------|
+| **Modern Primary** | tile, area, button, grid |
+| **Container** | vertical-stack, horizontal-stack, grid |
+| **Logic** | conditional, entity-filter |
+| **Display** | sensor, history-graph, statistics-graph, gauge, energy, calendar, distribution |
+| **Legacy Control** | entity, entities, light, thermostat (use tile instead) |
+
+**Default:** Use `tile` card for most entities. Use `references/dashboard-cards.md` to look up all card types or fetch card-specific docs.
+
+### Tile Card
+
+```json
+{
+  "type": "tile",
+  "entity": "climate.bedroom",
+  "name": "Master Bedroom",
+  "icon": "mdi:thermostat",
+  "features": [
+    {"type": "target-temperature"},
+    {"type": "climate-hvac-modes", "style": "dropdown"}
+  ],
+  "tap_action": {"action": "more-info"}
+}
+```
+
+### Grid Card
+
+```json
+{
+  "type": "grid",
+  "columns": 3,
+  "square": false,
+  "cards": [
+    {"type": "tile", "entity": "light.kitchen"},
+    {"type": "tile", "entity": "light.dining"},
+    {"type": "tile", "entity": "light.hallway"}
+  ]
+}
+```
+
+---
+
+## Features
+
+Quick controls available on tile, area, humidifier, and thermostat cards.
+
+| Domain | Feature types |
+|--------|--------------|
+| Climate | `climate-hvac-modes`, `climate-fan-modes`, `climate-preset-modes`, `target-temperature` |
+| Light | `light-brightness`, `light-color-temp` |
+| Cover | `cover-open-close`, `cover-position`, `cover-tilt` |
+| Fan | `fan-speed`, `fan-direction`, `fan-oscillate` |
+| Media | `media-player-playback`, `media-player-volume-slider` |
+| Valve | `valve-open-close`, `valve-position` |
+| Other | `toggle`, `button`, `alarm-modes`, `lock-commands`, `numeric-input`, `datetime-picker` |
+
+### Tile Card Extras (2025.9+)
+
+Tile cards support additional display features beyond controls:
+- **Trend graph**: 24-hour history sparkline for numeric entities (enabled in tile card config)
+- **Bar gauge**: Percentage-based bar display for numeric entities
+- **Action buttons**: Run automations/scripts directly from tile cards
+
+Feature `style` options: `"dropdown"` or `"icons"`
+
+---
+
+## Actions
+
+```json
+{
+  "tap_action": {"action": "toggle"},
+  "hold_action": {"action": "more-info"},
+  "double_tap_action": {"action": "navigate", "navigation_path": "/lovelace/lights"}
+}
+```
+
+Action types: `toggle`, `call-service`, `more-info`, `navigate`, `url`, `none`
+
+### Visibility Conditions
+
+```json
+{
+  "visibility": [
+    {"condition": "user", "users": ["user_id_hex"]},
+    {"condition": "state", "entity": "sun.sun", "state": "above_horizon"}
+  ]
+}
+```
+
+---
+
+## Custom Cards
+
+Use custom JavaScript cards when built-in cards don't support your visualization.
+
+### Minimal Custom Card
+
+```javascript
+class MyCard extends HTMLElement {
+  setConfig(config) {
+    if (!config.entity) throw new Error("Please define an entity");
+    this.config = config;
+  }
+  set hass(hass) {
+    if (!this.content) {
+      this.innerHTML = `<ha-card header="${this.config.title || 'My Card'}">
+        <div class="card-content"></div>
+      </ha-card>`;
+      this.content = this.querySelector(".card-content");
+    }
+    const state = hass.states[this.config.entity];
+    this.content.innerHTML = state ? `State: ${state.state}` : "Entity not found";
+  }
+  getCardSize() { return 2; }
+}
+customElements.define("my-card", MyCard);
+window.customCards = window.customCards || [];
+window.customCards.push({ type: "my-card", name: "My Card", description: "A custom card" });
+```
+
+Usage: `{"type": "custom:my-card", "entity": "sensor.temperature"}`
+
+For isolated styling, use Shadow DOM (`this.attachShadow({ mode: "open" })`) and scope CSS inside the shadow root.
+
+### Hosting
+
+Use the HA dashboard resource API to convert inline code to a hosted URL, then register as a dashboard resource. Size limit: ~24KB source code.
+
+### Custom Card Workflow
+
+1. Write the card JavaScript class (see Minimal Custom Card above)
+2. Register it as a dashboard resource via the HA REST API (`/api/config/lovelace/resources`) with `resource_type: "module"`
+3. Use the card in your dashboard config with the `custom:` prefix
+
+```json
+{
+  "type": "custom:quick-status-card",
+  "entity": "sensor.temperature",
+  "name": "Living Room"
+}
+```
+
+---
+
+## CSS Styling
+
+### Theme Overrides
+
+```css
+:root {
+  --primary-color: #03a9f4;
+  --ha-card-background: rgba(26, 26, 46, 0.9);
+  --ha-card-border-radius: 16px;
+  --ha-card-box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+```
+
+### Card-mod (Per-Card Styling)
+
+Requires the `card-mod` HACS component:
+
+```yaml
+type: entities
+card_mod:
+  style: |
+    ha-card {
+      --ha-card-background: teal;
+      color: var(--primary-color);
+    }
+entities:
+  - light.bed_light
+```
+
+---
+
+## HACS Integration
+
+| Use case | Solution |
+|----------|----------|
+| Popular community card | HACS — search and install via HACS API |
+| Small custom styling | Inline CSS — register via HA dashboard resource API |
+| One-off custom card | Inline module — register via HA dashboard resource API |
+| Large/complex card | HACS or filesystem (`/config/www/`) |
+
+### Finding and Installing Cards
+
+Search HACS for community cards by name/category, review repository details, then install. HACS install operations are destructive — clients will ask for user confirmation.
+
+### Popular HACS Cards
+
+- **mushroom** — Modern, clean card collection
+- **button-card** — Highly customizable buttons
+- **mini-graph-card** — Compact graphs
+- **card-mod** — CSS styling for any card
+- **layout-card** — Advanced layout control
+- **apexcharts-card** — Professional charts
+
+---
+
+## Complete Example: Multi-View Dashboard
+
+```json
+{
+  "views": [
+    {
+      "title": "Overview",
+      "path": "home",
+      "type": "sections",
+      "max_columns": 4,
+      "badges": ["person.john", "person.jane"],
+      "sections": [
+        {
+          "title": "Quick Actions",
+          "cards": [{
+            "type": "grid",
+            "columns": 4,
+            "square": false,
+            "cards": [
+              {"type": "button", "name": "Lights", "icon": "mdi:lightbulb", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/lights"}},
+              {"type": "button", "name": "Climate", "icon": "mdi:thermostat", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/climate"}},
+              {"type": "button", "name": "Security", "icon": "mdi:shield-home", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/security"}},
+              {"type": "button", "name": "Energy", "icon": "mdi:lightning-bolt", "tap_action": {"action": "navigate", "navigation_path": "/lovelace/energy"}}
+            ]
+          }]
+        },
+        {
+          "title": "Favorites",
+          "cards": [{
+            "type": "grid",
+            "columns": 3,
+            "square": false,
+            "cards": [
+              {"type": "tile", "entity": "light.living_room", "features": [{"type": "light-brightness"}]},
+              {"type": "tile", "entity": "climate.bedroom", "features": [{"type": "target-temperature"}]},
+              {"type": "tile", "entity": "lock.front_door"}
+            ]
+          }]
+        }
+      ]
+    },
+    {
+      "title": "Lights",
+      "path": "lights",
+      "type": "sections",
+      "icon": "mdi:lightbulb",
+      "max_columns": 3,
+      "sections": [
+        {
+          "title": "Living Room",
+          "cards": [{
+            "type": "grid",
+            "columns": 3,
+            "cards": [
+              {"type": "tile", "entity": "light.overhead", "features": [{"type": "light-brightness"}]},
+              {"type": "tile", "entity": "light.lamp", "features": [{"type": "light-brightness"}]},
+              {"type": "tile", "entity": "light.accent", "features": [{"type": "light-color-temp"}]}
+            ]
+          }]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Common Pitfalls
+
+| Issue | Solution |
+|-------|----------|
+| url_path rejected | New dashboards need a hyphen: `my-dashboard` not `mydashboard`. Use `lovelace` for the default dashboard. |
+| Entity not found | Use full entity ID: `light.living_room` not `living_room` |
+| Features not working | Match feature type to entity domain (e.g., `light-brightness` only works on `light.*`) |
+| Custom card not loading | Check resource type is `module` and verify URL is accessible |
+| Card too large for inline | Use HACS or filesystem instead |
+
+---
+
+## Modern Best Practices (2024+)
+
+- Use **sections** view type with grid-based layouts
+- Use **tile** cards as primary card type (replaces legacy entity/light/climate cards)
+- Use **grid** cards for multi-column layouts within sections
+- Create **multiple views** with navigation paths (avoid single-view endless scrolling)
+- Use **area** cards with navigation for hierarchical organization
+
+### Recent Dashboard Features (2026.2–2026.4)
+
+| Feature | Version | Details |
+|---------|---------|---------|
+| **Distribution card** | 2026.2 | Proportional horizontal bars across multiple entities (power monitoring, storage usage) |
+| **Section background colors** | 2026.4 | Sections support custom `background_color` with adjustable opacity |
+| **Card favorites** | 2026.4 | Light color favorites and cover position favorites display on tile/light cards |
+| **Auto-height cards** | 2026.4 | Cards auto-adjust height based on content via the layout editor |
+
+**Legacy patterns to avoid:**
+- Single-view dashboards with all cards in one long scroll
+- Excessive use of vertical-stack/horizontal-stack instead of grid
+- Masonry view (auto-layout) — use sections for precise control
+- Putting all entities in generic "entities" cards
+
+---
+
+## Visual Iteration Workflow
+
+For iterative dashboard design with visual feedback, add a browser automation MCP server:
+
+### Recommended MCP Servers
+
+- **Playwright MCP** (`@anthropic/mcp-playwright`) — Take screenshots, interact with pages
+- **Puppeteer MCP** — Similar browser automation capabilities
+- **Browser DevTools MCP** — Inspect elements, debug layouts
+
+### Workflow
+
+```
+1. Create/update dashboard via the HA config API
+2. Navigate browser to dashboard URL (e.g., http://homeassistant.local:8123/lovelace/my-dashboard)
+3. Take screenshot to see current layout
+4. Analyze screenshot for issues (spacing, alignment, colors)
+5. Adjust configuration and repeat
+```
+
+### Example with Playwright MCP
+
+```
+1. Get the HA base URL from the system overview (e.g., "http://homeassistant.local:8123")
+2. Update dashboard config via the HA REST API
+3. Navigate browser to {base_url}/lovelace/{url_path}
+4. Take screenshot → analyze → adjust → repeat
+```
+
+### Benefits
+
+- See actual rendered output, not just JSON config
+- Catch visual issues (card overlap, responsive breakpoints)
+- Verify custom card styling
+- Test on different viewport sizes

--- a/tools/ha-best-practices/references/device-control.md
+++ b/tools/ha-best-practices/references/device-control.md
@@ -1,0 +1,439 @@
+# Device Control Patterns
+
+Best practices for controlling devices, triggering from Zigbee buttons/remotes, and structuring service calls.
+
+---
+
+## Entity ID vs Device ID
+
+### The Core Problem
+
+`device_id` is a Home Assistant internal identifier that **changes when a device is re-added** (e.g., after Zigbee mesh repair, integration re-setup, or hardware replacement). Automations using `device_id` will break silently.
+
+`entity_id` is user-controllable, stable across device re-adds, and can be renamed for clarity.
+
+### Device Triggers vs State Triggers
+
+```yaml
+# ❌ WRONG - device_id changes if device is re-added
+triggers:
+  - trigger: device
+    device_id: abc123def456
+    domain: binary_sensor
+    type: motion
+
+# ✅ RIGHT - entity_id is stable and renameable
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.hallway_motion
+    to: "on"
+```
+
+### When Device ID is Acceptable
+
+The only cases where `device_id` might be acceptable:
+
+1. **Device-only triggers** - Some devices expose triggers without entities (see Zigbee section)
+2. **Temporary automations** - Quick tests you'll delete
+3. **UI-created automations** - The UI defaults to device triggers; convert to entity triggers for production
+
+---
+
+## Service Calls Best Practices
+
+### Use target: Structure
+
+Modern Home Assistant service calls use the `target:` key to specify entities, areas, or devices:
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 100
+```
+
+### Target Types
+
+| Type | Use case | Persistence |
+|------|----------|-------------|
+| `entity_id` | Specific entities | ✅ Stable (recommended) |
+| `area_id` | All entities in a room | ✅ Stable |
+| `device_id` | All entities on a device | ❌ Changes on re-add |
+
+### Multiple Targets
+
+```yaml
+# Multiple entities
+target:
+  entity_id:
+    - light.living_room
+    - light.kitchen
+    - light.bedroom
+
+# Area targeting (all lights in living room)
+target:
+  area_id: living_room
+
+# Combined (entities + areas)
+target:
+  entity_id: light.hallway
+  area_id:
+    - bedroom
+    - bathroom
+```
+
+### Template in Targets
+
+```yaml
+# Dynamic entity selection
+target:
+  entity_id: "{{ state_attr('sensor.motion_zone', 'light_entity') }}"
+
+# All lights currently on (advanced)
+target:
+  entity_id: >
+    {{ states.light
+       | selectattr('state', 'eq', 'on')
+       | map(attribute='entity_id')
+       | list }}
+```
+
+---
+
+## Zigbee Button/Remote Patterns
+
+### ZHA (Zigbee Home Automation)
+
+ZHA buttons fire `zha_event` events. Use **event triggers** with `device_ieee` (the device's IEEE address), which is **persistent** across re-adds.
+
+```yaml
+# ✅ ZHA button trigger - device_ieee is persistent
+triggers:
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      device_ieee: "00:15:8d:00:07:26:f2:8a"
+      command: "toggle"
+```
+
+For a complete multi-button remote with trigger_id + choose, see `references/examples.yaml` Example 2.
+
+#### Finding ZHA Event Data
+
+1. Go to **Developer Tools → Events**
+2. Subscribe to `zha_event`
+3. Press your button
+4. Copy the `device_ieee` and `command` values
+
+### Zigbee2MQTT (Z2M)
+
+Z2M creates **MQTT device triggers** that are autodiscovered. These are acceptable because Z2M manages the device-to-trigger mapping.
+
+```yaml
+# ✅ Z2M device trigger - autodiscovered
+triggers:
+  - trigger: device
+    device_id: abc123def456  # OK for Z2M, managed by autodiscovery
+    domain: mqtt
+    type: action
+    subtype: single
+
+# Alternative: MQTT topic trigger (more explicit)
+triggers:
+  - trigger: mqtt
+    topic: "zigbee2mqtt/Bedroom Button/action"
+    payload: "single"
+```
+
+#### Z2M Device Trigger Discovery
+
+1. Open your device in **Settings → Devices**
+2. Look for available triggers under "Automations"
+3. The UI will show valid trigger types and subtypes
+
+### Z2M vs ZHA Comparison
+
+| Aspect | ZHA | Zigbee2MQTT |
+|--------|-----|-------------|
+| Trigger type | `event` trigger | `device` trigger or `mqtt` trigger |
+| Identifier | `device_ieee` (persistent) | `device_id` (autodiscovered) |
+| Event name | `zha_event` | MQTT device trigger |
+| Button actions | `command` field | `type` and `subtype` |
+
+---
+
+## Domain-Specific Patterns
+
+### Lights
+
+**Color temperature:** Always use `color_temp_kelvin` (e.g., `3000`). The legacy `color_temp` parameter (in mireds) was removed in 2026.3.
+
+```yaml
+# Turn on with brightness and transition
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 80
+      transition: 2
+      color_temp_kelvin: 3000
+
+# Turn on multiple lights differently
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.main
+    data:
+      brightness_pct: 100
+  - action: light.turn_on
+    target:
+      entity_id: light.accent
+    data:
+      brightness_pct: 30
+      rgb_color: [255, 147, 41]
+```
+
+### Climate
+
+```yaml
+# Set temperature with HVAC mode
+actions:
+  - action: climate.set_temperature
+    target:
+      entity_id: climate.living_room
+    data:
+      temperature: 22
+      hvac_mode: heat
+
+# Set preset mode
+actions:
+  - action: climate.set_preset_mode
+    target:
+      entity_id: climate.living_room
+    data:
+      preset_mode: away
+```
+
+### Covers (Blinds/Shades)
+
+```yaml
+# Set to specific position (0 = closed, 100 = open)
+actions:
+  - action: cover.set_cover_position
+    target:
+      entity_id: cover.living_room_blinds
+    data:
+      position: 50
+
+# Tilt control
+actions:
+  - action: cover.set_cover_tilt_position
+    target:
+      entity_id: cover.living_room_blinds
+    data:
+      tilt_position: 75
+```
+
+### Media Players
+
+```yaml
+# Play media
+actions:
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.living_room_speaker
+    data:
+      media_content_id: "https://example.com/audio.mp3"
+      media_content_type: music
+
+# Set volume (0.0 to 1.0)
+actions:
+  - action: media_player.volume_set
+    target:
+      entity_id: media_player.living_room_speaker
+    data:
+      volume_level: 0.5
+```
+
+### Notifications
+
+```yaml
+# Mobile app notification
+actions:
+  - action: notify.mobile_app_phone
+    data:
+      title: "Motion Detected"
+      message: "Motion in {{ trigger.to_state.attributes.friendly_name }}"
+      data:
+        tag: "motion-alert"
+        actions:
+          - action: "DISMISS"
+            title: "Dismiss"
+          - action: "VIEW_CAMERA"
+            title: "View Camera"
+
+# Persistent notification
+actions:
+  - action: notify.persistent_notification
+    data:
+      title: "Reminder"
+      message: "Check the laundry"
+      notification_id: "laundry_reminder"
+```
+
+---
+
+## Vacuum Control
+
+```yaml
+# Start cleaning
+actions:
+  - action: vacuum.start
+    target:
+      entity_id: vacuum.roborock
+
+# Return to dock
+actions:
+  - action: vacuum.return_to_base
+    target:
+      entity_id: vacuum.roborock
+
+# Clean specific areas (2026.3+ — uses HA areas, not vendor room IDs)
+# Requires mapping vacuum segments to HA areas in entity settings first
+# Supported integrations include Matter, Ecovacs, Roborock (list may grow)
+actions:
+  - action: vacuum.clean_area
+    target:
+      entity_id: vacuum.roborock
+    data:
+      area_id:
+        - kitchen
+        - living_room
+```
+
+**Prefer `vacuum.clean_area`** when the user has mapped vacuum segments to HA areas (entity settings). It works across supported integrations without vendor lock-in.
+
+**Fallback:** When the integration doesn't support `clean_area` or segments aren't mapped, use `vacuum.send_command` with integration-specific parameters:
+
+```yaml
+# Integration-specific room cleaning (fallback)
+actions:
+  - action: vacuum.send_command
+    target:
+      entity_id: vacuum.roborock
+    data:
+      command: app_segment_clean
+      params:
+        - 16  # Vendor-specific room ID
+        - 17
+```
+
+Suggest the user configure segment-to-area mapping when possible to avoid vendor lock-in.
+
+---
+
+## Response Data
+
+Some services return data. Use `response_variable` to capture it:
+
+```yaml
+actions:
+  - action: weather.get_forecasts
+    target:
+      entity_id: weather.home
+    data:
+      type: hourly
+    response_variable: forecast
+  - action: notify.mobile_app_phone
+    data:
+      message: "Tomorrow's high: {{ forecast['weather.home'].forecast[0].temperature }}°C"
+```
+
+---
+
+## Common Mistakes
+
+### ❌ Using entity_id in data instead of target
+
+```yaml
+# WRONG (deprecated)
+actions:
+  - action: light.turn_on
+    data:
+      entity_id: light.living_room
+      brightness: 255
+
+# RIGHT
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness: 255
+```
+
+### ❌ Hardcoding device_id for regular devices
+
+```yaml
+# WRONG - breaks on device re-add
+actions:
+  - action: light.turn_on
+    target:
+      device_id: abc123def456
+
+# RIGHT
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+```
+
+### ❌ Forgetting service data structure
+
+```yaml
+# WRONG - brightness_pct at wrong level
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    brightness_pct: 100
+
+# RIGHT - brightness_pct inside data
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.living_room
+    data:
+      brightness_pct: 100
+```
+
+---
+
+## Quick Reference: Service Call Structure
+
+```yaml
+actions:
+  - action: domain.service_name   # Required
+    target:                       # Optional but recommended
+      entity_id: entity.id        # Single or list
+      area_id: area_name          # Single or list
+      device_id: device_id        # Avoid except for Z2M
+    data:                         # Service-specific parameters
+      parameter: value
+    response_variable: result     # Capture response (if needed)
+```
+
+## Quick Reference: Trigger Types for Devices
+
+| Device Type | ZHA | Zigbee2MQTT | Generic |
+|-------------|-----|-------------|---------|
+| Button/Remote | `event` (zha_event) | `device` or `mqtt` | `state` |
+| Motion sensor | `state` | `state` | `state` |
+| Door/Window | `state` | `state` | `state` |
+| Temperature | `state` or `numeric_state` | `state` or `numeric_state` | `state` or `numeric_state` |
+| Switch | `state` | `state` | `state` |
+
+Always prefer `state` triggers with `entity_id` for sensors and switches. Only use event/device triggers for stateless devices (buttons, remotes).

--- a/tools/ha-best-practices/references/domain-docs.md
+++ b/tools/ha-best-practices/references/domain-docs.md
@@ -1,0 +1,43 @@
+# Domain Documentation
+
+To get detailed documentation for any Home Assistant integration or entity domain, fetch from the official docs on demand.
+
+## Fetching Domain Docs
+
+```
+https://raw.githubusercontent.com/home-assistant/home-assistant.io/refs/heads/current/source/_integrations/{domain}.markdown
+```
+
+Replace `{domain}` with the integration name (e.g., `light`, `climate`, `mqtt`).
+
+If the MCP server registers resource URI templates for domain docs, prefer those over raw GitHub fetches.
+
+## Common Domains
+
+| Domain | Description |
+|--------|-------------|
+| `light` | Light control (brightness, color, temperature) |
+| `switch` | On/off switches |
+| `climate` | HVAC and thermostat control |
+| `cover` | Blinds, shades, garage doors |
+| `fan` | Fan speed and oscillation |
+| `lock` | Door locks |
+| `media_player` | Media playback and volume |
+| `vacuum` | Robot vacuum control |
+| `sensor` | Numeric and text sensors |
+| `binary_sensor` | On/off sensors (motion, door, window) |
+| `automation` | Automation management |
+| `script` | Script management |
+| `scene` | Scene activation |
+| `input_boolean` | Toggle helpers |
+| `input_number` | Numeric input helpers |
+| `input_select` | Dropdown helpers |
+| `input_datetime` | Date/time helpers |
+| `mqtt` | MQTT broker and entities |
+| `zha` | Zigbee Home Automation |
+| `notify` | Notification services |
+| `tts` | Text-to-speech |
+| `camera` | Camera feeds and snapshots |
+| `weather` | Weather forecasts |
+| `person` | Person/presence tracking |
+| `zone` | Geographic zones |

--- a/tools/ha-best-practices/references/examples.yaml
+++ b/tools/ha-best-practices/references/examples.yaml
@@ -1,0 +1,326 @@
+# =============================================================================
+# Home Assistant Best Practices - Compound Examples
+# =============================================================================
+# Each example demonstrates MULTIPLE best practices working together.
+# For individual patterns, see the corresponding reference file.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 1: Motion-Activated Light (restart mode)
+# -----------------------------------------------------------------------------
+# Demonstrates: restart mode, state trigger, native time condition, wait_for_trigger
+# Best practice: Use restart mode so re-triggering resets the timeout
+
+automation:
+  - id: motion_light_hallway
+    alias: "Hallway Motion Light"
+    description: "Turn on hallway light when motion detected, auto-off after 3 minutes"
+    mode: restart  # Re-trigger resets the timer
+
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.hallway_motion
+        to: "on"
+
+    conditions:
+      # Native time condition - no template needed
+      - condition: time
+        after: "06:00:00"
+        before: "23:00:00"
+
+    actions:
+      - action: light.turn_on
+        target:
+          entity_id: light.hallway
+        data:
+          brightness_pct: 80
+          transition: 1
+
+      # wait_for_trigger - event-driven, waits for the change
+      - wait_for_trigger:
+          - trigger: state
+            entity_id: binary_sensor.hallway_motion
+            to: "off"
+            for:
+              minutes: 3
+        timeout:
+          minutes: 10
+        continue_on_timeout: true
+
+      - action: light.turn_off
+        target:
+          entity_id: light.hallway
+        data:
+          transition: 3
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 2: Multi-Button Remote with trigger_id
+# -----------------------------------------------------------------------------
+# Demonstrates: ZHA event trigger, device_ieee (persistent), trigger_id, choose
+# Best practice: Use device_ieee instead of device_id for ZHA
+
+  - id: bedroom_remote_control
+    alias: "Bedroom Remote Control"
+    description: "Handle single, double, and hold presses on ZHA button"
+    mode: single
+
+    triggers:
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"  # Replace with your device
+          command: "single"
+        id: single_press
+
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"
+          command: "double"
+        id: double_press
+
+      - trigger: event
+        event_type: zha_event
+        event_data:
+          device_ieee: "00:15:8d:00:07:26:f2:8a"
+          command: "hold"
+        id: hold
+
+    actions:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: single_press
+            sequence:
+              - action: light.toggle
+                target:
+                  entity_id: light.bedroom
+
+          - conditions:
+              - condition: trigger
+                id: double_press
+            sequence:
+              - action: light.turn_on
+                target:
+                  area_id: bedroom
+                data:
+                  brightness_pct: 100
+
+          - conditions:
+              - condition: trigger
+                id: hold
+            sequence:
+              - action: light.turn_off
+                target:
+                  area_id: bedroom
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 3: Door Lock Notification with Queued Mode
+# -----------------------------------------------------------------------------
+# Demonstrates: queued mode, state condition with attribute, not condition, template message
+# Best practice: Use queued mode when order matters
+
+  - id: door_unlock_notification
+    alias: "Door Unlock Notification"
+    description: "Notify when door is unlocked, show who unlocked it"
+    mode: queued  # Process each unlock event in order
+    max: 10
+
+    triggers:
+      - trigger: state
+        entity_id: lock.front_door
+        to: "unlocked"
+
+    conditions:
+      # Native not + state condition with attribute check - no template
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: lock.front_door
+            attribute: changed_by
+            state: "auto_unlock"
+
+    actions:
+      - action: notify.mobile_app_phone
+        data:
+          title: "Front Door Unlocked"
+          message: "Unlocked by {{ state_attr('lock.front_door', 'changed_by') }}"
+          data:
+            tag: "door-unlock"
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 4: Parallel Mode for Per-Entity Actions
+# -----------------------------------------------------------------------------
+# Demonstrates: parallel mode, multi-entity trigger, trigger variable in template target
+# Best practice: Use parallel mode when actions are independent per-entity
+
+  - id: window_open_climate_off
+    alias: "Turn Off Climate When Window Opens"
+    description: "Turn off climate in room when window is opened"
+    mode: parallel  # Handle multiple windows independently
+    max: 10
+
+    triggers:
+      - trigger: state
+        entity_id:
+          - binary_sensor.bedroom_window
+          - binary_sensor.living_room_window
+          - binary_sensor.kitchen_window
+        to: "on"
+
+    actions:
+      # Use trigger variable to determine which room
+      - action: climate.turn_off
+        target:
+          entity_id: >
+            {% set room = trigger.entity_id.split('.')[1].replace('_window', '') %}
+            climate.{{ room }}
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 5: Doorbell with if/then and Native Time Condition
+# -----------------------------------------------------------------------------
+# Demonstrates: if/then action, native time condition, quiet hours logic
+# Best practice: Use if/then for simple binary, choose for multiple branches
+
+  - id: doorbell_announcement
+    alias: "Doorbell Announcement"
+    description: "Announce doorbell with different messages based on time"
+    mode: single
+
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+
+    actions:
+      - if:
+          - condition: time
+            after: "22:00:00"
+            before: "08:00:00"
+        then:
+          # Quiet hours - just notification
+          - action: notify.mobile_app_phone
+            data:
+              title: "Doorbell"
+              message: "Someone is at the door"
+        else:
+          # Normal hours - announce and notification
+          - action: tts.speak
+            target:
+              entity_id: tts.google_say
+            data:
+              media_player_entity_id: media_player.living_room_speaker
+              message: "Someone is at the front door"
+          - action: notify.mobile_app_phone
+            data:
+              title: "Doorbell"
+              message: "Someone is at the door"
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 6: Script with fields, sequence, and mode
+# -----------------------------------------------------------------------------
+# Demonstrates: correct script schema (sequence not actions), fields for
+# parameterization, mode selection, area targeting, multiple service calls
+# Best practice: Use the HA config API to create scripts programmatically
+# rather than generating YAML snippets for manual file editing
+
+script:
+  good_night:
+    alias: "Good Night"
+    description: "Turn off lights, lock doors, and set thermostat for sleeping"
+    icon: mdi:weather-night
+    mode: single
+    fields:
+      sleep_temp:
+        name: Sleep Temperature
+        description: "Target temperature for sleeping"
+        selector:
+          number:
+            min: 60
+            max: 75
+            unit_of_measurement: "°F"
+        default: 68
+    sequence:
+      - action: light.turn_off
+        target:
+          area_id:
+            - living_room
+            - kitchen
+            - bedroom
+
+      - action: lock.lock
+        target:
+          entity_id:
+            - lock.front_door
+            - lock.back_door
+
+      - action: climate.set_temperature
+        target:
+          entity_id: climate.main
+        data:
+          temperature: "{{ sleep_temp }}"
+          hvac_mode: heat
+
+      - action: notify.mobile_app_phone
+        data:
+          message: "Good night! Lights off, doors locked, thermostat set to {{ sleep_temp }}°F."
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE 7: MQTT entity configuration
+# -----------------------------------------------------------------------------
+# Demonstrates: three approaches to creating MQTT entities, in order of
+# preference. The anti-pattern table says "don't tell users to edit
+# configuration.yaml for integrations" — MQTT now supports UI-based setup.
+#
+# APPROACH 1 (RECOMMENDED): MQTT Subentries via UI
+# Settings > Devices & Services > MQTT > Add MQTT device
+# Supports: sensor, switch, light, climate, cover, fan, lock, button,
+# number, select, text, alarm_control_panel, valve, water_heater, and more.
+# No restart required. Fill in state_topic, device_class, etc. in the UI.
+#
+# APPROACH 2 (PREFERRED for devices): MQTT Discovery
+# Compatible devices (ESPHome, Tasmota, Zigbee2MQTT) announce themselves
+# to the broker. HA auto-creates entities with zero manual configuration.
+# The device publishes a JSON config payload to a discovery topic:
+
+# Example discovery payload published by device to:
+# homeassistant/sensor/outdoor_temp/config
+#
+# {
+#   "name": "Outdoor Temperature",
+#   "state_topic": "home/outdoor/temperature",
+#   "unit_of_measurement": "°C",
+#   "device_class": "temperature",
+#   "state_class": "measurement",
+#   "value_template": "{{ value_json.temperature }}",
+#   "unique_id": "outdoor_temp_001",
+#   "device": {
+#     "identifiers": ["outdoor_weather_station"],
+#     "name": "Outdoor Weather Station"
+#   }
+# }
+
+# APPROACH 3 (LEGACY FALLBACK): YAML in configuration.yaml
+# Only use if subentries don't support the entity platform yet, or if the
+# user explicitly requests YAML config.
+mqtt:
+  sensor:
+    - name: "Outdoor Temperature"
+      state_topic: "home/outdoor/temperature"
+      unit_of_measurement: "°C"
+      device_class: temperature
+      state_class: measurement
+      value_template: "{{ value_json.temperature }}"
+
+  binary_sensor:
+    - name: "Garage Door"
+      state_topic: "home/garage/door"
+      payload_on: "open"
+      payload_off: "closed"
+      device_class: garage_door

--- a/tools/ha-best-practices/references/helper-selection.md
+++ b/tools/ha-best-practices/references/helper-selection.md
@@ -1,0 +1,696 @@
+# Helper Selection Guide
+
+This document covers Home Assistant's built-in helpers and integrations that should be used instead of template sensors or complex automations.
+
+## Table of Contents
+1. [Numeric Aggregation](#numeric-aggregation) - min_max, statistics
+2. [Rate and Change](#rate-and-change) - derivative, threshold
+3. [Time-Based Tracking](#time-based-tracking) - utility_meter, history_stats, integration (Riemann sum)
+4. [State Storage](#state-storage) - input_boolean, input_number, input_select, input_text, input_datetime, input_button
+5. [Counting and Timing](#counting-and-timing) - counter, timer
+6. [Scheduling](#scheduling) - schedule, time of day (tod)
+7. [Entity Grouping](#entity-grouping) - group, binary sensor groups
+
+---
+
+## Numeric Aggregation
+
+### min_max
+
+**Use for:** Combining multiple sensors to get min, max, mean, median, sum, or last value across all of them.
+
+**Instead of:**
+```yaml
+# WRONG - Template sensor for averaging
+template:
+  - sensor:
+      - name: "Average Temperature"
+        state: >
+          {{ ((states('sensor.temp_bedroom') | float) +
+              (states('sensor.temp_living') | float) +
+              (states('sensor.temp_kitchen') | float)) / 3 }}
+```
+
+**Use this:**
+```yaml
+# RIGHT - min_max helper
+sensor:
+  - platform: min_max
+    name: "Average Temperature"
+    type: mean
+    entity_ids:
+      - sensor.temp_bedroom
+      - sensor.temp_living
+      - sensor.temp_kitchen
+```
+
+**Available types:** `min`, `max`, `mean`, `median`, `last`, `sum`
+
+**Key behaviors:**
+- Ignores `unknown` states (except `sum` which goes to unknown)
+- Returns error if unit of measurement differs between sensors
+- For spiky values, filter with statistics sensor first
+
+**Common uses:**
+- Average house temperature from multiple room sensors
+- Maximum power consumption across circuits
+- Sum of all solar panel production sensors
+
+---
+
+### statistics
+
+**Use for:** Statistical analysis over time for a single sensor (mean, median, stdev, change, variance, etc.).
+
+**Instead of:**
+```yaml
+# WRONG - Complex template tracking history
+template:
+  - sensor:
+      - name: "Temperature Change"
+        state: "{{ states('sensor.temp') | float - state_attr('sensor.temp', 'last_value') | float(0) }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Statistics helper
+sensor:
+  - platform: statistics
+    name: "Temperature Change (5 min)"
+    entity_id: sensor.temperature
+    state_characteristic: change
+    max_age:
+      minutes: 5
+    sampling_size: 50
+```
+
+**Available characteristics:**
+- `mean`, `median`, `average_linear`, `average_step`, `average_timeless`
+- `standard_deviation`, `variance`
+- `change`, `change_second`, `change_sample`
+- `count`, `count_binary_on`, `count_binary_off`
+- `total`, `noisiness`
+- `datetime_newest`, `datetime_oldest`, `datetime_value_max`, `datetime_value_min`
+- `value_max`, `value_min`, `quantiles`
+
+**Key behaviors:**
+- Time-based (`max_age`) vs count-based (`sampling_size`) buffering
+- If using `max_age`, ensure frequent enough readings to cover the period
+- Different from Long-Term Statistics (which is automatic for sensors with `state_class`)
+
+**Common uses:**
+- Humidity change over last hour
+- Standard deviation of power readings (detect anomalies)
+- Count of motion sensor activations in last 24 hours
+
+---
+
+## Rate and Change
+
+### derivative
+
+**Use for:** Calculating rate of change over time.
+
+**Instead of:**
+```yaml
+# WRONG - Template calculating delta manually
+template:
+  - sensor:
+      - name: "Power Rate"
+        state: "{{ (states('sensor.power') | float - states('sensor.power_previous') | float) / 60 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Derivative helper
+sensor:
+  - platform: derivative
+    name: "Power Rate of Change"
+    source: sensor.power
+    unit_time: min
+    time_window:
+      minutes: 5
+```
+
+**Parameters:**
+- `unit_time`: s, min, h, d - determines output unit (e.g., W/min)
+- `time_window`: Smoothing window using Simple Moving Average
+- `round`: Decimal places for output
+
+**Key behaviors:**
+- Without `time_window`, calculates between consecutive updates only
+- Can show large negative spikes when source resets to 0 (total_increasing sensors)
+- Use `force_update` option if source updates infrequently
+
+**Common uses:**
+- Energy production rate (kW from kWh sensor)
+- Temperature change rate (detect HVAC efficiency)
+- Water flow rate from cumulative meter
+
+---
+
+### threshold
+
+**Use for:** Creating a binary sensor that turns on/off when a numeric sensor crosses a threshold.
+
+**Instead of:**
+```yaml
+# WRONG - Template binary sensor
+template:
+  - binary_sensor:
+      - name: "High Temperature"
+        state: "{{ states('sensor.temperature') | float > 25 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Threshold helper
+binary_sensor:
+  - platform: threshold
+    name: "High Temperature"
+    entity_id: sensor.temperature
+    upper: 25
+    hysteresis: 1
+```
+
+**Parameters:**
+- `upper`: Threshold for "on" when value exceeds
+- `lower`: Threshold for "on" when value drops below
+- `hysteresis`: Buffer zone to prevent rapid toggling
+
+**Hysteresis explained:**
+```
+With upper: 25 and hysteresis: 1:
+- Turns ON when value rises ABOVE 26 (25 + 1)
+- Turns OFF when value falls BELOW 24 (25 - 1)
+```
+
+**Common uses:**
+- Low battery warning (lower threshold)
+- High humidity alert
+- Air quality threshold alerts
+- Detect temperature rising/falling (use with derivative)
+
+---
+
+## Time-Based Tracking
+
+### utility_meter
+
+**Use for:** Tracking consumption with periodic resets (energy, water, gas billing cycles).
+
+**Instead of:**
+```yaml
+# WRONG - Automation with counter tracking monthly usage
+automation:
+  - alias: "Reset monthly energy"
+    triggers:
+      - trigger: time
+        at: "00:00:00"
+    conditions:
+      - "{{ now().day == 1 }}"
+    actions:
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.monthly_energy
+        data:
+          value: 0
+```
+
+**Use this:**
+```yaml
+# RIGHT - Utility meter
+utility_meter:
+  daily_energy:
+    source: sensor.energy_consumption
+    cycle: daily
+  monthly_energy:
+    source: sensor.energy_consumption
+    cycle: monthly
+```
+
+**Cycle options:** `quarter-hourly`, `hourly`, `daily`, `weekly`, `monthly`, `bimonthly`, `quarterly`, `yearly`
+
+**Advanced features:**
+- **Tariffs:** Track peak/off-peak separately
+- **Offset:** Start cycle on specific day (e.g., billing date)
+- **Cron:** Custom reset schedules
+- **Delta:** For sensors that report delta values
+
+```yaml
+# Utility meter with tariffs
+utility_meter:
+  daily_energy:
+    source: sensor.energy_consumption
+    cycle: daily
+    tariffs:
+      - peak
+      - offpeak
+```
+
+Then use automation to switch tariffs:
+```yaml
+automation:
+  - alias: "Switch to peak tariff"
+    triggers:
+      - trigger: time
+        at: "07:00:00"
+    actions:
+      - action: utility_meter.select_tariff
+        target:
+          entity_id: utility_meter.daily_energy
+        data:
+          tariff: peak
+```
+
+**Common uses:**
+- Daily/monthly energy consumption
+- Water usage per billing cycle
+- Gas consumption tracking
+
+---
+
+### history_stats
+
+**Use for:** Statistics about how long/often an entity has been in a specific state.
+
+```yaml
+sensor:
+  - platform: history_stats
+    name: "Lights on today"
+    entity_id: light.living_room
+    state: "on"
+    type: time
+    start: "{{ now().replace(hour=0, minute=0, second=0) }}"
+    end: "{{ now() }}"
+```
+
+**Types:**
+- `time`: Duration in hours
+- `ratio`: Percentage of time
+- `count`: Number of state changes to the monitored state
+
+**Key behaviors:**
+- Limited by recorder's `purge_keep_days`
+- Updates when source changes or once per minute
+
+**Common uses:**
+- How long lights were on today
+- Percentage of time home was occupied
+- Count of door openings per day
+
+---
+
+### integration (Riemann sum)
+
+**Use for:** Converting power (W) to energy (kWh), flow rate to volume, etc.
+
+```yaml
+sensor:
+  - platform: integration
+    name: "Solar Energy"
+    source: sensor.solar_power
+    unit_prefix: k
+    unit_time: h
+    method: left
+    round: 2
+```
+
+**Methods:**
+- `left`: Uses previous value for interval (recommended for sparse data)
+- `right`: Uses new value for interval
+- `trapezoidal`: Averages previous and new (can overestimate with gaps)
+
+**Key behaviors:**
+- For solar/sensors with gaps, use `left` method
+- `max_sub_interval` forces updates even when source doesn't change
+
+**Common uses:**
+- Convert solar power (W) to energy production (kWh)
+- Convert water flow rate to total consumption
+- Convert gas flow to total usage
+
+---
+
+## State Storage
+
+### input_boolean
+
+**Use for:** Toggle switches for modes, flags, and conditions.
+
+```yaml
+input_boolean:
+  guest_mode:
+    name: "Guest Mode"
+    icon: mdi:account-group
+  vacation_mode:
+    name: "Vacation Mode"
+    icon: mdi:airplane
+```
+
+**Common uses:**
+- Guest mode (disable certain automations)
+- Vacation mode
+- Manual override flags
+- Feature toggles
+
+### input_number
+
+**Use for:** Storing numeric values that can be adjusted.
+
+```yaml
+input_number:
+  target_temperature:
+    name: "Target Temperature"
+    min: 15
+    max: 30
+    step: 0.5
+    unit_of_measurement: "°C"
+    mode: slider
+```
+
+**Modes:** `slider`, `box`
+
+**Common uses:**
+- User-adjustable thresholds
+- Target temperatures
+- Timer durations
+- Brightness levels
+
+### input_select
+
+**Use for:** Dropdown selection of predefined options.
+
+```yaml
+input_select:
+  hvac_mode:
+    name: "HVAC Mode"
+    options:
+      - "auto"
+      - "cool"
+      - "heat"
+      - "off"
+    icon: mdi:thermostat
+```
+
+**Common uses:**
+- Scene selection
+- Mode selection
+- Status tracking
+- Multi-state toggles
+
+### input_text
+
+**Use for:** Storing text strings.
+
+```yaml
+input_text:
+  notification_message:
+    name: "Custom Notification"
+    min: 0
+    max: 255
+    mode: text
+```
+
+**Modes:** `text`, `password`
+
+**Common uses:**
+- Custom messages
+- Temporary storage
+- User notes
+
+### input_datetime
+
+**Use for:** Storing date and/or time values.
+
+```yaml
+input_datetime:
+  morning_alarm:
+    name: "Morning Alarm"
+    has_time: true
+    has_date: false
+  next_vacation:
+    name: "Next Vacation"
+    has_date: true
+    has_time: false
+```
+
+**Common uses:**
+- Alarm times
+- Schedule times (wake-up, lights off)
+- Future dates (vacation, events)
+
+### input_button
+
+**Use for:** Triggering automations manually.
+
+```yaml
+input_button:
+  doorbell:
+    name: "Doorbell"
+    icon: mdi:bell
+```
+
+**Common uses:**
+- Manual triggers for automations
+- Dashboard buttons
+- Test triggers
+
+---
+
+## Counting and Timing
+
+### counter
+
+**Use for:** Tracking counts with increment/decrement/reset.
+
+**Instead of:**
+```yaml
+# WRONG - input_number with automation
+input_number:
+  coffee_count:
+    min: 0
+    max: 100
+automation:
+  - alias: "Increment coffee"
+    triggers: ...
+    actions:
+      - action: input_number.set_value
+        data:
+          value: "{{ states('input_number.coffee_count') | int + 1 }}"
+```
+
+**Use this:**
+```yaml
+# RIGHT - Counter helper
+counter:
+  coffee_count:
+    name: "Coffees Today"
+    initial: 0
+    step: 1
+    minimum: 0
+    maximum: 100
+    restore: true
+```
+
+**Actions:** `counter.increment`, `counter.decrement`, `counter.reset`, `counter.set_value`
+
+**Key behaviors:**
+- `restore: true` preserves value across restarts
+- Respects min/max boundaries
+
+**Common uses:**
+- Daily counts (coffees, workouts)
+- Usage tracking
+- Sequential numbering
+
+---
+
+### timer
+
+**Use for:** Countdown timers that fire events when finished.
+
+**Instead of:**
+```yaml
+# WRONG - Delay in automation
+actions:
+  - delay:
+      minutes: 5
+  - action: notify.mobile_app
+    data:
+      message: "Timer done!"
+```
+
+**Use this for pausable/restartable timers:**
+```yaml
+# RIGHT - Timer helper
+timer:
+  laundry:
+    name: "Laundry Timer"
+    duration: "01:00:00"
+    restore: true
+```
+
+**Actions:** `timer.start`, `timer.pause`, `timer.cancel`, `timer.finish`, `timer.change`
+
+**Events fired:**
+- `timer.started`
+- `timer.paused`
+- `timer.cancelled`
+- `timer.finished`
+- `timer.restarted`
+
+**Key behaviors:**
+- Can be started with custom duration: `timer.start` with `duration: "00:30:00"`
+- `restore: true` continues timer after restart
+- Can be controlled from dashboard
+
+**Common uses:**
+- Laundry/dryer reminders
+- Cooking timers
+- Activity timers with pause/resume
+
+---
+
+## Scheduling
+
+### schedule
+
+**Use for:** Weekly on/off schedules.
+
+```yaml
+schedule:
+  work_hours:
+    name: "Work Hours"
+    monday:
+      - from: "09:00:00"
+        to: "17:00:00"
+    tuesday:
+      - from: "09:00:00"
+        to: "17:00:00"
+    # ... etc
+```
+
+**Key behaviors:**
+- Creates a binary sensor that's `on` during scheduled times
+- Can have multiple blocks per day
+- Editable via UI
+
+**Instead of:**
+```yaml
+# WRONG - Template with weekday checks
+template:
+  - binary_sensor:
+      - name: "Work Hours"
+        state: >
+          {{ now().weekday() < 5 and
+             now().hour >= 9 and
+             now().hour < 17 }}
+```
+
+**Common uses:**
+- Work hours / business hours
+- Quiet hours
+- HVAC schedules
+- Lighting schedules
+
+---
+
+### time of day (tod)
+
+**Use for:** Binary sensor based on current time (sunrise/sunset or fixed times).
+
+```yaml
+binary_sensor:
+  - platform: tod
+    name: "Morning"
+    after: "06:00"
+    before: "12:00"
+
+  - platform: tod
+    name: "Night Time"
+    after: sunset
+    after_offset: "01:00:00"
+    before: sunrise
+```
+
+**Common uses:**
+- Time-of-day modes (morning, afternoon, evening, night)
+- Daylight/darkness detection
+- Simple time-based conditions
+
+---
+
+## Entity Grouping
+
+### group
+
+**Use for:** Combining entities for collective state and control.
+
+```yaml
+group:
+  all_lights:
+    name: "All Lights"
+    entities:
+      - light.living_room
+      - light.bedroom
+      - light.kitchen
+    all: false  # ON if ANY member is on
+
+  security_sensors:
+    name: "Security Sensors"
+    entities:
+      - binary_sensor.front_door
+      - binary_sensor.back_door
+      - binary_sensor.window
+    all: true  # ON only if ALL members are on
+```
+
+**Parameters:**
+- `all: false` (default): Group is ON if ANY member is ON (OR logic)
+- `all: true`: Group is ON only if ALL members are ON (AND logic)
+
+**Key behaviors:**
+- Groups inherit the domain of their members
+- Light groups can be controlled as a single entity
+- Binary sensor groups useful for "any door open" logic
+
+**Instead of:**
+```yaml
+# WRONG - Template binary sensor for any-on logic
+template:
+  - binary_sensor:
+      - name: "Any Door Open"
+        state: >
+          {{ is_state('binary_sensor.front_door', 'on') or
+             is_state('binary_sensor.back_door', 'on') }}
+```
+
+**Common uses:**
+- All lights in an area
+- Any motion sensor active
+- All doors/windows closed
+- Group control in dashboards
+
+---
+
+## Decision Matrix
+
+| Need | Helper | Not |
+|------|--------|-----|
+| Average of multiple sensors | `min_max` (type: mean) | Template with math |
+| Sum of multiple sensors | `min_max` (type: sum) | Template with math |
+| Average over time | `statistics` | Template tracking history |
+| Rate of change | `derivative` | Template calculating delta |
+| On/off at threshold | `threshold` | Template binary sensor |
+| Consumption per period | `utility_meter` | Counter with reset automation |
+| Time in state | `history_stats` | Template tracking timestamps |
+| Power to energy | `integration` | Template approximating |
+| User toggle | `input_boolean` | - |
+| User number | `input_number` | - |
+| User selection | `input_select` | - |
+| Count events | `counter` | input_number + automation |
+| Countdown timer | `timer` | delay + input_datetime |
+| Weekly schedule | `schedule` | Template with weekday checks |
+| Time of day mode | `tod` | Template with time checks |
+| Any-on / all-on | `group` | Template binary sensor |

--- a/tools/ha-best-practices/references/safe-refactoring.md
+++ b/tools/ha-best-practices/references/safe-refactoring.md
@@ -1,0 +1,246 @@
+# Safe Refactoring Workflow
+
+Follow this workflow whenever you modify existing Home Assistant configuration: renaming entities, replacing template sensors with helpers, converting device triggers, or restructuring automations.
+
+**Core rule:** Search all consumers BEFORE changing anything. Verify zero stale references AFTER.
+
+---
+
+## Universal Workflow
+
+### Step 1: Identify the full scope of change
+
+Answer three questions before touching anything:
+
+1. **What changes?** Entity ID, automation structure, sensor type, or trigger semantics.
+2. **What sibling entities share the same device?** Query the device to list every entity it owns (battery sensor, update entity, diagnostic button). Plan changes for all siblings together.
+   - Query the device via the HA REST API (`GET /api/states/<entity_id>`) or inspect Settings > Devices.
+3. **Rename one entity or all device entities?** Devices bundle 2-6 entities. Renaming the primary but leaving siblings with the old naming scheme creates inconsistency.
+
+### Step 2: Search ALL consumers
+
+Search every component type that references entity IDs. Do not limit searches to the component you are editing.
+
+| Component | How to search |
+|-----------|---------------|
+| Automations | Search automations for the entity ID via the HA API or grep `automations.yaml` |
+| Dashboards | Search dashboard configs for the entity ID via the HA API or grep `.storage/lovelace*`, `ui-lovelace.yaml` |
+| Scripts | grep `scripts.yaml` |
+| Scenes | grep `scenes.yaml` |
+| Config-Entry-based groups | `GET /api/config/config_entries/entry?type=config&domain=group` — members in `options.entities`; entity registry renames do NOT update these automatically (→ see Config-Entry-Groups section) |
+| Config-Entry integrations (Better Thermostat, Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper) | `GET /api/config/config_entries/entry` — scan `data` and `options` fields for the old entity ID; entity registry renames do NOT update these fields automatically (→ see Config-Entry-Data section) |
+| Other | Check AppDaemon apps, Node-RED flows, Pyscript scripts, or any custom integration that references entity IDs |
+
+Record every location found. This list becomes your update checklist for Step 4.
+
+### Step 3: Make the change
+
+Rename the entity, replace the template sensor, or restructure the automation.
+
+### Step 4: Update every consumer
+
+Work through each location from your Step 2 checklist. Update every reference to the new entity ID, helper entity, or automation structure.
+
+### Step 5: Verify
+
+1. **Search for the OLD identifier** across all component types. Expect zero results.
+   - Search for the old entity ID via the HA API or grep all config files.
+2. **Search for the NEW identifier** to confirm all expected locations reference it.
+3. **Reload or check dashboards** if entity IDs changed.
+4. **If stale references remain that you cannot update**, rename the entity back to its original ID to restore functionality, then report the blocking locations to the user.
+
+---
+
+## Entity Renames
+
+Additional requirements beyond the universal workflow:
+
+**Device-sibling discovery (Step 1):**
+HA devices bundle multiple entities. A smart plug might expose `switch.*`, `sensor.*_energy`, and `update.*`. A multi-sensor exposes motion, temperature, illuminance, and battery entities. Rename all siblings to match.
+
+Example — renaming a smart plug's entities from manufacturer defaults to room-based names:
+
+| Domain | Old entity ID | New entity ID |
+|---|---|---|
+| switch | `switch.shellyplug_s_a1b2c3d4e5f6` | `switch.office_heater` |
+| sensor | `sensor.shellyplug_s_a1b2c3d4e5f6_energy` | `sensor.office_heater_energy` |
+| update | `update.shellyplug_s_a1b2c3d4e5f6` | `update.office_heater` |
+
+**Dashboard reference locations (Step 2):**
+Dashboard cards reference entities in multiple places. Search all of these:
+
+- `entity:` field
+- `tap_action` and `hold_action` targets
+- Conditional card conditions
+- Template card Jinja2 blocks
+- `views[n].badges` — badge rows per view; badges are siblings of the cards array, not children, so any card-focused search will miss them — always search the full dashboard config
+- `views[n].header.card` — sections view only (HA 2025.3+); the view header accepts a Markdown card that supports Jinja2 templates and may contain entity references; it is a sibling of the cards array and is not reachable via card-focused search
+
+---
+
+## Helper Replacements
+
+When replacing a template sensor with a built-in helper (`min_max`, `threshold`, `derivative`):
+
+**New entity ID (Step 1):**
+The helper creates a new entity with a different entity_id. The old template sensor's entity_id stops existing. Update every consumer of the old entity_id to reference the new one.
+
+**Test equivalence (Step 5):**
+Verify the new helper produces the same values as the old template sensor. Check units, precision, and unavailable-state handling.
+
+---
+
+## Trigger Restructuring
+
+When converting `device_id` triggers to `entity_id` triggers, or replacing `wait_template` with `wait_for_trigger`:
+
+**Behavioral equivalence (Step 1):**
+`wait_for_trigger` waits for a state *change*; `wait_template` polls for *current state*. These differ when the target state is already true at wait start: `wait_for_trigger` blocks indefinitely, `wait_template` returns immediately.
+
+**Automation callers (Step 2):**
+Search for scripts or other automations that call the automation you are restructuring via `automation.trigger` or `automation.turn_on`. Renaming or splitting an automation changes its entity_id and breaks these callers.
+
+---
+
+## Config-Entry-Groups
+
+When renaming entities that are members of a HA **group** created via the UI (Config-Entry-based group, platform: `group`):
+
+**Entity registry renames do NOT update group members automatically.**
+
+Group member entity IDs are stored in `options.entities` of the group's Config Entry — not in the entity registry. A registry rename leaves the group referencing the old (now non-existent) entity ID, silently breaking it.
+
+**Detection (Step 2):**
+List all Config-Entry-based groups to get their `entry_id` values:
+
+```http
+GET /api/config/config_entries/entry?type=config&domain=group
+```
+
+> **Note:** Some HA MCP integrations may not expose all fields from the Config Entries API
+> response — in particular, `options.entities` may be absent. Use the REST endpoint above
+> to confirm current group members directly.
+
+To inspect current members of a specific group, initiate an Options Flow and read
+`suggested_value` in the returned `data_schema.entities` field:
+
+```http
+POST /api/config/config_entries/options/flow
+{"handler": "<group_config_entry_id>"}
+```
+
+> **One active flow per Config Entry:** HA allows only one active Options Flow per Config
+> Entry at a time. If you open a detection flow to read current values, abandon or complete
+> it before initiating the fix flow. To abandon:
+>
+> ```http
+> DELETE /api/config/config_entries/options/flow/<flow_id>
+> ```
+
+**Fix (Step 4):**
+After the registry rename, update group membership via the Options Flow.
+
+1. Initiate a new fix flow (the detection flow from above must be abandoned or completed
+   first). Read the current option values from `suggested_value`. Note the `flow_id`:
+
+```http
+POST /api/config/config_entries/options/flow
+{"handler": "<group_config_entry_id>"}
+```
+
+2. Submit the updated member list, preserving existing `hide_members` value.
+   Include `all` only if it was present in the step 1 `data_schema` response — only
+   `light`, `switch`, and `binary_sensor` groups support it. For all other group types
+   (fan, lock, media_player, sensor, etc.) omit `all` entirely:
+
+```http
+POST /api/config/config_entries/options/flow/<flow_id>
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>}
+```
+
+   If the group type supports `all`, add it explicitly:
+
+```http
+POST /api/config/config_entries/options/flow/<flow_id>
+{"entities": ["new.entity_id_1", "new.entity_id_2"], "hide_members": <suggested_value>, "all": <suggested_value>}
+```
+
+> **Safe rule:** Always derive field presence from the step 1 `data_schema` response —
+> never hardcode fields. Submitting unknown fields may result in a validation error.
+
+**Verify (Step 5):**
+Re-initiate the Options Flow for the group's `entry_id` and confirm that `suggested_value`
+for `entities` contains only the updated entity IDs. The REST endpoint
+`GET /api/config/config_entries/entry` does not expose `options.entities` — the Options
+Flow is the only way to read current group members.
+
+
+## Config-Entry Data — Blind Spots for entity registry renames
+
+**Entity registry renames only update the Entity Registry.** Integrations that collect entity_ids during their setup flow store them in the Config Entry — not in YAML and not in the Entity Registry. A registry rename leaves these references pointing to the old (now non-existent) entity ID.
+
+**Affected integrations and storage fields:**
+
+| Integration | Storage field | Fields containing entity_ids |
+|---|---|---|
+| **Better Thermostat** | `data` (not accessible via REST — see note below) | `temperature_sensor`, `humidity_sensor`, `outdoor_sensor`, `window_sensors` |
+| Generic Thermostat | `options` | `heater`, `target_sensor` |
+| Generic Hygrostat | `options` | `humidifier`, `target_sensor` |
+| Threshold Helper | `options` | `entity_id` |
+| Min/Max Helper | `options` | `entity_ids` |
+
+**Symptom:** Integration reports "associated entity missing" or behaves incorrectly after restart.
+
+**Timing:** Patch Config-Entry data fields **before the HA restart**. An integration that starts with stale entity_ids can cause integration setup failures on restart.
+
+**Scan via REST API:**
+```http
+GET /api/config/config_entries/entry
+```
+Iterate the returned entries and check `data` and `options` fields for the old entity ID.
+
+> **Note:** Some custom integrations (including Better Thermostat) do not expose their entity references in `data` or `options` via this endpoint — the fields may appear empty even when the integration is configured. For these integrations, the REST scan will return no matches; the Fix section below documents whether an alternative fix path exists.
+
+**Fix:**
+
+For integrations that store entity_ids in `options` (Generic Thermostat, Generic Hygrostat, Threshold Helper, Min/Max Helper): use the Options Flow. See the Config-Entry-Groups section above for the full Options Flow pattern.
+
+For integrations that store entity_ids in `data` (Better Thermostat): `data` fields written during the initial Config Flow setup have no standard API for post-setup mutation — the Options Flow updates `options` only. No API-based fix path exists. Document this limitation to the user before proceeding with a rename.
+
+---
+
+
+## Storage-Mode-Dashboards (`.storage/lovelace.*`)
+
+**Entity registry renames do NOT update Lovelace storage dashboards.**
+
+**Recommended fix — no restart required:**
+
+Use the Lovelace WebSocket API (`lovelace/config` to read, `lovelace/config/save` to write):
+
+```
+1. Read dashboard config:
+   WebSocket: {"type": "lovelace/config", "url_path": "<dashboard_url_path>"}
+   Note: the default (Overview) dashboard requires `"url_path": null`; custom dashboards use their string path.
+   → returns full dashboard config (JSON)
+
+2. Replace entity IDs (Python — JSON-aware, boundary-safe):
+   def _replace_ids(obj, old_id, new_id):
+       if isinstance(obj, str): return new_id if obj == old_id else obj
+       if isinstance(obj, list): return [_replace_ids(i, old_id, new_id) for i in obj]
+       if isinstance(obj, dict): return {(new_id if k == old_id else k): _replace_ids(v, old_id, new_id) for k, v in obj.items()}
+       return obj
+   new_config = _replace_ids(config, "old.entity_id", "new.entity_id")
+   # Note: string replace on json.dumps() is not boundary-safe — it matches entity IDs
+   # that appear as JSON keys or as substrings of other strings in the serialized output.
+
+3. Write dashboard config:
+   WebSocket: {"type": "lovelace/config/save", "url_path": "<dashboard_url_path>", "config": new_config}
+   Note: use `"url_path": null` for the default (Overview) dashboard; use the string path for custom dashboards.
+   → takes effect immediately, no restart required
+```
+
+
+
+**List all storage dashboards:**
+WebSocket: `{"type": "lovelace/dashboards/list"}` → returns all dashboards with their url_path.

--- a/tools/ha-best-practices/references/template-guidelines.md
+++ b/tools/ha-best-practices/references/template-guidelines.md
@@ -1,0 +1,641 @@
+> **Prefer a Template Helper over YAML.**
+> Before writing any `template:` block, create a Template Helper via the HA config flow (MCP tool or API) or via the UI:
+> Settings → Devices & Services → Helpers → Create Helper → Template.
+> Use `template:` YAML only when explicitly requested or when neither programmatic nor UI access is available.
+
+# Template Guidelines
+
+This document covers when templates ARE the right choice in Home Assistant, and best practices for writing reliable templates.
+
+## Table of Contents
+1. [When Templates Are Appropriate](#when-templates-are-appropriate)
+2. [When to Avoid Templates](#when-to-avoid-templates)
+3. [Template Sensor Best Practices](#template-sensor-best-practices)
+4. [Automation Template Best Practices](#automation-template-best-practices)
+5. [Common Patterns](#common-patterns)
+6. [Error Handling](#error-handling)
+7. [Performance Considerations](#performance-considerations)
+
+---
+
+## When Templates Are Appropriate
+
+Templates are the RIGHT choice when:
+
+### 1. Dynamic Service Data
+
+You need to pass dynamic values to service calls based on entity states or trigger context.
+
+```yaml
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.bedroom
+    data:
+      brightness_pct: "{{ states('input_number.default_brightness') | int }}"
+      kelvin: "{{ 6500 if is_state('binary_sensor.daytime', 'on') else 2700 }}"
+```
+
+### 2. Dynamic Notification Messages
+
+Messages that include runtime information:
+
+```yaml
+actions:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {{ trigger.to_state.name }} has been {{ trigger.to_state.state }}
+        for {{ trigger.for.total_seconds() | int // 60 }} minutes.
+```
+
+### 3. Processing Raw Data Sources
+
+MQTT, REST, and command line sensors often provide raw data that needs transformation:
+
+```yaml
+# REST sensor with JSON response
+rest:
+  - resource: "http://api.example.com/data"
+    sensor:
+      - name: "Temperature"
+        value_template: "{{ value_json.current.temperature }}"
+        unit_of_measurement: "°C"
+```
+
+### 4. Accessing Trigger Context
+
+Using `trigger.` variables in automations:
+
+```yaml
+actions:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {{ trigger.to_state.name }} changed from
+        {{ trigger.from_state.state }} to {{ trigger.to_state.state }}
+```
+
+### 5. Complex String Formatting
+
+When you need formatted output that can't be achieved with native constructs:
+
+```yaml
+template:
+  - sensor:
+      - name: "Friendly Uptime"
+        state: >
+          {% set uptime = states('sensor.system_uptime') | float(0) %}
+          {% set days = (uptime // 86400) | int %}
+          {% set hours = ((uptime % 86400) // 3600) | int %}
+          {% set minutes = ((uptime % 3600) // 60) | int %}
+          {{ days }}d {{ hours }}h {{ minutes }}m
+```
+
+### 6. Attribute Extraction
+
+Creating sensors from entity attributes:
+
+```yaml
+template:
+  - sensor:
+      - name: "Current Song Artist"
+        state: "{{ state_attr('media_player.spotify', 'media_artist') }}"
+```
+
+### 7. Complex Conditional State
+
+When the state depends on multiple factors that can't be expressed with native conditions:
+
+```yaml
+template:
+  - sensor:
+      - name: "Comfort Level"
+        state: >
+          {% set temp = states('sensor.temperature') | float(20) %}
+          {% set humidity = states('sensor.humidity') | float(50) %}
+          {% if temp >= 20 and temp <= 24 and humidity >= 40 and humidity <= 60 %}
+            Comfortable
+          {% elif temp < 18 or humidity < 30 %}
+            Too Cold/Dry
+          {% elif temp > 26 or humidity > 70 %}
+            Too Hot/Humid
+          {% else %}
+            Acceptable
+          {% endif %}
+```
+
+### 8. Entity Iteration
+
+Processing multiple entities dynamically:
+
+```yaml
+template:
+  - sensor:
+      - name: "Open Windows Count"
+        state: >
+          {{ states.binary_sensor
+             | selectattr('attributes.device_class', 'eq', 'window')
+             | selectattr('state', 'eq', 'on')
+             | list
+             | count }}
+```
+
+### 9. Date/Time Calculations
+
+Time differences, formatting, and calculations:
+
+```yaml
+template:
+  - sensor:
+      - name: "Days Until Event"
+        state: >
+          {% set event_date = as_datetime(states('input_datetime.event')) %}
+          {% set today = now().replace(hour=0, minute=0, second=0, microsecond=0) %}
+          {{ ((event_date - today).days) }}
+        unit_of_measurement: "days"
+```
+
+---
+
+## When to Avoid Templates
+
+Do NOT use templates when a native alternative exists:
+
+| Don't Use Template | Use Native |
+|-------------------|------------|
+| `{{ states('x') in ['a', 'b'] }}` | `condition: state` with `state: ["a", "b"]` |
+| `{{ states('x') \| float > 25 }}` | `condition: numeric_state` with `above: 25` |
+| `{{ now().hour >= 9 }}` | `condition: time` with `after: "09:00:00"` |
+| `{{ is_state('sun.sun', 'below_horizon') }}` | `condition: sun` with `after: sunset` |
+| `wait_template: "{{ is_state(...) }}"` | `wait_for_trigger` with state trigger |
+| Template sensor summing values | `min_max` helper with `type: sum` |
+| Template binary sensor with threshold | `threshold` helper |
+| Template sensor averaging over time | `statistics` helper |
+
+See `automation-patterns.md` and `helper-selection.md` for comprehensive alternatives.
+
+---
+
+## Template Sensor Best Practices
+
+### Always Include unique_id
+
+```yaml
+template:
+  - sensor:
+      - name: "My Sensor"
+        unique_id: my_custom_sensor  # Enables UI customization
+        state: "{{ states('sensor.source') }}"
+```
+
+### Always Define Availability
+
+Prevent errors and unknown states:
+
+```yaml
+template:
+  - sensor:
+      - name: "Safe Sensor"
+        unique_id: safe_sensor
+        availability: >
+          {{ has_value('sensor.source_a') and
+             has_value('sensor.source_b') }}
+        state: >
+          {{ states('sensor.source_a') | float +
+             states('sensor.source_b') | float }}
+```
+
+### Use Appropriate Device Class
+
+Helps with unit conversion and graph display:
+
+```yaml
+template:
+  - sensor:
+      - name: "Calculated Temperature"
+        device_class: temperature
+        unit_of_measurement: "°C"
+        state_class: measurement
+        state: "{{ states('sensor.raw_temp') | float / 10 }}"
+```
+
+### Use state_class for Long-Term Statistics (Recommended for Numeric Sensors)
+
+**If long-term statistics are needed, set `state_class`.** Without it, HA writes no
+long-term statistics — the sensor will not appear in `statistics_meta` or in History graphs.
+`state_class` is optional for diagnostic or one-shot sensors where statistics are not required.
+(Verified on HA 2026.3: `statistics_meta` empty without `state_class`, entry created after adding it.)
+
+> **Energy Dashboard note:** `state_class` alone is not sufficient for Energy Dashboard
+> visibility. The sensor also needs `device_class: energy` (or `power`, `gas`, etc.) to
+> appear as a selectable source. A sensor with `state_class` but no matching `device_class`
+> will have long-term statistics but will not appear in the Energy Dashboard configuration.
+
+Also mirror `device_class` from the source sensor where applicable (e.g., `duration`, `temperature`, `energy`).
+
+```yaml
+template:
+  - sensor:
+      - name: "Power Usage"
+        device_class: power
+        unit_of_measurement: "W"
+        state_class: measurement  # enables long-term statistics (omit if not needed)
+        state: "{{ states('sensor.amps') | float * 230 }}"
+```
+
+### Use Trigger-Based for Efficiency
+
+Trigger-based templates only update when sources change:
+
+```yaml
+template:
+  - triggers:                    # Recommended plural form (HA 2024.10+)
+      - trigger: state
+        entity_id:
+          - sensor.temp_bedroom
+          - sensor.temp_living
+    sensor:
+      - name: "Average Temperature"
+        state: >
+          {% set temps = [
+            states('sensor.temp_bedroom') | float(0),
+            states('sensor.temp_living') | float(0)
+          ] %}
+          {{ (temps | sum / temps | count) | round(1) }}
+        unit_of_measurement: "°C"
+        state_class: measurement
+```
+
+**Benefits of trigger-based:**
+- Only evaluates when trigger fires (not on every state change)
+- Access to `trigger` variable
+- More efficient for complex templates
+
+### YAML Block Structure Conventions (HA 2024.10+)
+
+**Use plural keys in trigger-based template blocks.** Since HA 2024.10 the recommended syntax
+uses `triggers:` and `actions:` (plural). The singular forms still work — there is no deprecation
+and no warnings — but all official HA docs now use plural. Write new templates in plural form.
+
+**Consolidate state-based entities of the same type in one block.** Multiple state-based
+`sensor` or `binary_sensor` entries without individual triggers belong in a single block —
+not in separate blocks per entity. Trigger-based blocks (with their own `triggers:` section)
+must be separate regardless of entity type, since each block defines its own trigger context:
+
+```yaml
+# CORRECT — state-based sensors: one block, multiple entries:
+template:
+  - binary_sensor:
+      - name: "Motion Room A"
+        unique_id: motion_room_a
+        state: "{{ ... }}"
+      - name: "Motion Room B"
+        unique_id: motion_room_b
+        state: "{{ ... }}"
+
+# AVOID — state-based sensors split across separate blocks:
+template:
+  - binary_sensor:
+      - name: "Motion Room A"
+        unique_id: motion_room_a_avoid
+        state: "{{ ... }}"
+  - binary_sensor:
+      - name: "Motion Room B"
+        unique_id: motion_room_b_avoid
+        state: "{{ ... }}"
+```
+
+> **Trigger-based blocks are always separate** — a block with `triggers:` defines its own
+> update context and cannot share a block with entries of a different trigger configuration.
+> Only consolidate entries that share the same trigger context (or are all state-based).
+
+**Follow HA's 2-space indentation rule ([HA YAML Style Guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/)).** In template blocks, list items under `sensor:` / `binary_sensor:` are indented 2 spaces relative to the key — which, combined with the `- ` sequence marker, results in 4 visual columns from the parent dash. This is the style used consistently in the official HA template integration documentation.
+
+```yaml
+# Standard — 2-space indent per level (HA Style Guide, matches official docs):
+- binary_sensor:
+    - name: "My Sensor"
+      state: "{{ ... }}"
+
+# Non-standard — compact notation (valid YAML, but absent from official HA docs):
+- binary_sensor:
+  - name: "My Sensor"
+```
+
+---
+
+## Automation Template Best Practices
+
+### Use Shorthand Syntax
+
+For template conditions, use the shorthand:
+
+```yaml
+# Shorthand (preferred)
+conditions:
+  - "{{ trigger.to_state.attributes.brightness > 100 }}"
+
+# Long form (equivalent but verbose)
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.brightness > 100 }}"
+```
+
+### Use Multiline Strings
+
+For readability in complex templates:
+
+```yaml
+actions:
+  - action: notify.mobile_app
+    data:
+      message: >
+        {% if is_state('binary_sensor.door', 'on') %}
+          Warning: Door is open!
+        {% else %}
+          All secure.
+        {% endif %}
+```
+
+### Access Trigger Context Properly
+
+```yaml
+automation:
+  - triggers:
+      - trigger: state
+        entity_id: light.bedroom
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: >
+            Light changed from {{ trigger.from_state.state }}
+            to {{ trigger.to_state.state }}
+            Entity: {{ trigger.entity_id }}
+            Brightness: {{ trigger.to_state.attributes.brightness | default('N/A') }}
+```
+
+---
+
+## Common Patterns
+
+### Safe State Access
+
+Always use `states()` function, not `states.sensor.x.state`:
+
+```yaml
+# GOOD - Returns 'unknown' if entity doesn't exist
+{{ states('sensor.temperature') }}
+
+# BAD - Errors if entity doesn't exist
+{{ states.sensor.temperature.state }}
+```
+
+### Safe Numeric Conversion
+
+```yaml
+# GOOD - Default value if conversion fails
+{{ states('sensor.temperature') | float(0) }}
+
+# BAD - Errors if state is 'unavailable' or 'unknown'
+{{ states('sensor.temperature') | float }}
+```
+
+### Check for Valid State
+
+```yaml
+{% if has_value('sensor.temperature') %}
+  Temperature is {{ states('sensor.temperature') }}°C
+{% else %}
+  Temperature unavailable
+{% endif %}
+```
+
+### Multiple States Check
+
+```yaml
+{% if is_state('light.a', 'on') and is_state('light.b', 'on') %}
+  Both lights on
+{% endif %}
+```
+
+### List of States
+
+```yaml
+{% if states('alarm_control_panel.home') in ['armed_home', 'armed_away', 'armed_night'] %}
+  Alarm is armed
+{% endif %}
+```
+
+### Attribute Access with Default
+
+```yaml
+{{ state_attr('light.bedroom', 'brightness') | default(0) }}
+```
+
+### Time Since State Change
+
+```yaml
+{% set last_changed = states.binary_sensor.motion.last_changed %}
+{% set seconds = (now() - last_changed).total_seconds() %}
+{{ (seconds / 60) | round(0) }} minutes ago
+```
+
+### Filter Entities by Attribute
+
+```yaml
+{% set open_windows = states.binary_sensor
+   | selectattr('attributes.device_class', 'defined')
+   | selectattr('attributes.device_class', 'eq', 'window')
+   | selectattr('state', 'eq', 'on')
+   | list %}
+{{ open_windows | count }} windows open
+```
+
+### Iterate with Index
+
+```yaml
+{% for light in states.light %}
+  {{ loop.index }}: {{ light.name }} is {{ light.state }}
+{% endfor %}
+```
+
+### Format Lists Human-Readable
+
+```yaml
+{% set items = ['apples', 'oranges', 'bananas'] %}
+{{ items[:-1] | join(', ') }} and {{ items[-1] }}
+{# Output: apples, oranges and bananas #}
+```
+
+---
+
+## Error Handling
+
+### Default Values
+
+```yaml
+# For numeric operations
+{{ states('sensor.x') | float(default=0) }}
+{{ states('sensor.x') | int(default=-1) }}
+
+# For attribute access
+{{ state_attr('light.x', 'brightness') | default(100) }}
+
+# For entire template failures
+{{ states('sensor.missing') | default('Unknown', true) }}
+```
+
+### Availability Template
+
+```yaml
+template:
+  - sensor:
+      - name: "Calculated Value"
+        availability: "{{ has_value('sensor.input') }}"
+        state: "{{ states('sensor.input') | float * 2 }}"
+```
+
+### Check Before Use
+
+```yaml
+{% if is_state_attr('media_player.tv', 'is_volume_muted', false) %}
+  Volume: {{ state_attr('media_player.tv', 'volume_level') | float * 100 }}%
+{% else %}
+  Muted
+{% endif %}
+```
+
+### Handle None Attributes
+
+```yaml
+{% set attr = state_attr('sensor.x', 'some_attr') %}
+{% if attr is not none %}
+  Attribute value: {{ attr }}
+{% else %}
+  Attribute not available
+{% endif %}
+```
+
+---
+
+## Performance Considerations
+
+### Avoid Expensive Operations in Value Templates
+
+Templates in `value_template` for sensors update on EVERY state change of the source entity.
+
+```yaml
+# EXPENSIVE - Runs on every source sensor update
+sensor:
+  - platform: template
+    sensors:
+      expensive_sensor:
+        value_template: >
+          {% for entity in states %}  {# Iterates ALL entities #}
+            ...
+          {% endfor %}
+```
+
+### Use Trigger-Based Templates for Complex Logic
+
+```yaml
+# EFFICIENT - Only runs when specified triggers fire
+template:
+  - triggers:
+      - trigger: time_pattern
+        minutes: "/5"  # Every 5 minutes
+    sensor:
+      - name: "Complex Calculation"
+        state: >
+          {% set total = 0 %}
+          {% for sensor in states.sensor | selectattr('attributes.device_class', 'eq', 'energy') %}
+            {% set total = total + states(sensor.entity_id) | float(0) %}
+          {% endfor %}
+          {{ total }}
+```
+
+### Cache Complex Calculations
+
+If you need the same value in multiple places, create one template sensor and reference it:
+
+```yaml
+# ONE template sensor
+template:
+  - sensor:
+      - name: "House Occupancy Count"
+        state: >
+          {{ states.person | selectattr('state', 'eq', 'home') | list | count }}
+
+# Reference it elsewhere
+automation:
+  - condition: numeric_state
+    entity_id: sensor.house_occupancy_count
+    above: 0
+```
+
+### Use Variables for Repeated Access
+
+```yaml
+{% set temp = states('sensor.temperature') | float(0) %}
+{% set humidity = states('sensor.humidity') | float(0) %}
+
+{% if temp > 25 and humidity > 70 %}
+  Hot and humid
+{% elif temp > 25 %}
+  Hot (temp: {{ temp }}°C)
+{% endif %}
+```
+
+---
+
+## Quick Reference: Functions and Filters
+
+### State Functions
+
+| Function | Purpose |
+|----------|---------|
+| `states('entity_id')` | Get entity state (string) |
+| `state_attr('entity_id', 'attr')` | Get attribute value |
+| `is_state('entity_id', 'state')` | Check if entity has state |
+| `is_state_attr('entity_id', 'attr', 'value')` | Check attribute value |
+| `has_value('entity_id')` | True if not unknown/unavailable |
+| `entity_name('entity_id')` | Get entity display name; preferred over `friendly_name` attribute (2026.4+) |
+| `state_attr_translated('entity_id', 'attr')` | Get translated attribute value, e.g., fan modes, HVAC actions (2026.4+) |
+
+### Common Filters
+
+| Filter | Purpose |
+|--------|---------|
+| `float(default)` | Convert to float |
+| `int(default)` | Convert to int |
+| `round(precision)` | Round number |
+| `default(value)` | Provide fallback |
+| `timestamp_custom(format)` | Format timestamp |
+| `from_json` | Parse JSON string |
+| `to_json` | Convert to JSON string |
+| `regex_match(pattern)` | Regex match |
+| `regex_replace(find, replace)` | Regex replace |
+
+### Time Functions
+
+| Function | Purpose |
+|----------|---------|
+| `now()` | Current datetime |
+| `utcnow()` | Current UTC datetime |
+| `today_at('HH:MM')` | Today at specific time |
+| `as_timestamp(dt)` | Convert to Unix timestamp |
+| `as_datetime(ts)` | Convert from timestamp |
+| `as_timedelta(string)` | Parse duration string |
+
+### Collection Filters
+
+| Filter | Purpose |
+|--------|---------|
+| `selectattr('attr', 'eq', 'value')` | Filter by attribute |
+| `rejectattr('attr', 'eq', 'value')` | Exclude by attribute |
+| `map(attribute='state')` | Extract attribute from list |
+| `list` | Convert to list |
+| `count` | Count items |
+| `first` / `last` | Get first/last item |
+| `sum` / `min` / `max` | Aggregate values |

--- a/tools/ha-best-practices/references/yaml-only-integrations.md
+++ b/tools/ha-best-practices/references/yaml-only-integrations.md
@@ -1,0 +1,21 @@
+# YAML-Only Integrations
+
+Use managed YAML config editing (with backup, validation, and `check_config` verification) for integrations that have no config flow and no REST/WebSocket API for creation.
+
+This does NOT apply to automations/scripts/scenes (use config APIs), UI-configured integrations, `.storage/` files (use REST/WebSocket APIs), or helpers like input_number/input_boolean (these have config flow).
+
+## YAML-Only Integration Types
+
+| Integration type | Post-edit action | Notes |
+|---|---|---|
+| `template` | Reload available | Prefer Template Helper (UI) when possible |
+| `mqtt` (platform-based) | Reload available | Platform-style `mqtt:` sensors/switches; MQTT devices via config entry are separate |
+| `group` (YAML-defined) | Reload available | Groups defined in YAML; UI groups use config entries |
+| `command_line` | Restart required | Sensors, switches, binary sensors via shell commands |
+| `rest` | Restart required | REST sensors, binary sensors |
+| `shell_command` | Restart required | Named shell command definitions |
+| `notify` (legacy platform-based) | Restart required | Most notify platforms now use config entries; only legacy platform-based definitions are YAML-only |
+| `sensor` / `binary_sensor` | Restart required | Platform-style YAML definitions (e.g. `sensor: platform: xyz`) |
+| `switch` / `light` / `fan` / `cover` / `climate` | Restart required | Platform-based YAML definitions |
+
+Confirm with the user before triggering a restart — it briefly interrupts all automations and integrations.

--- a/tools/integrations/_discovery.md
+++ b/tools/integrations/_discovery.md
@@ -12,11 +12,12 @@ This workflow is **read-only** and passive-first. It collects signals, ranks can
 2. Probe mDNS with `avahi-browse -atr`.
 3. Probe SSDP.
 4. If passive evidence is still insufficient, fall back to active LAN evidence:
-   - `ip neigh`
-   - `arp-scan`
-   - `nmap`
+   - `arp-scan --localnet`
+   - `nmap -sn <subnet>`
+   - `ip neigh show`
 5. Present the results as candidates, not as implied mutation requests.
-6. Require explicit user confirmation before any config-flow start or add-device action.
+6. Hand confirmed candidates into `tools/integrations/_lifecycle.md`.
+7. Require explicit user confirmation before any config-flow start or add-device action.
 
 ## Operating Rules
 
@@ -24,6 +25,25 @@ This workflow is **read-only** and passive-first. It collects signals, ranks can
 - Selecting a discovered device candidate still requires explicit user confirmation before any add-device action.
 - Do not start `ha_config_entries_flow` from this doc.
 - Do not add devices from this doc.
+- If a command is missing or the shell lacks permission, treat that as a tooling constraint, not as proof that no devices exist.
+- Continue down the active fallback chain only when passive evidence is insufficient or inconclusive.
+- Stop the discovery phase with "no candidate devices found" only after the passive sources and the ordered fallback chain have all been exhausted or ruled out.
+
+## Active Fallback Chain
+
+Use this exact order when passive evidence is insufficient:
+
+1. `arp-scan --localnet`
+   - Best first active step when available because it returns MAC addresses that match the fingerprint corpus cleanly.
+   - If `arp-scan` is not installed or requires privileges you do not have, note that constraint and continue to `nmap -sn`.
+2. `nmap -sn <subnet>`
+   - Use this when `arp-scan --localnet` is unavailable or insufficient.
+   - If `nmap` is missing, blocked, or returns too little evidence to fingerprint confidently, continue to `ip neigh show`.
+3. `ip neigh show`
+   - Final low-assumption fallback when active scanners are unavailable.
+   - Use it to salvage local ARP/neighbor evidence before concluding that no strong candidates were found.
+
+Do not reorder these steps at runtime. Report which rung of the chain produced the useful evidence, and distinguish "tool missing" / "permission denied" from "scan returned no candidates."
 
 ## Fingerprint Corpus
 
@@ -50,3 +70,5 @@ Summarize what you found in plain language:
 - what active fallback evidence was needed, if any
 
 Keep the message framed as discovery, not action. The next step is always the user's explicit confirmation.
+
+Once the user confirms a candidate, hand off into `tools/integrations/_lifecycle.md`.

--- a/tools/integrations/_guide.md
+++ b/tools/integrations/_guide.md
@@ -1,10 +1,18 @@
-# Integrations — Setup Guide
+# Integrations — Config-Flow Sub-Skill
+
+This file is a sub-skill for the `CONNECTING` phase in `tools/integrations/_lifecycle.md`.
+
+Primary route:
+
+`tools/integrations/_discovery.md` → `tools/integrations/_lifecycle.md` → `tools/integrations/_guide.md`
 
 Every integration has its own setup flow with different steps and options. **Do NOT hardcode or assume what the options are.**
 
 ### Discovery First
 
 Use `tools/integrations/_discovery.md` as the read-only entrypoint before any mutation step. It is passive-first: check existing HA signals first, then mDNS via `avahi-browse -atr`, then SSDP, and only fall back to `ip neigh`, `arp-scan`, and `nmap` when passive evidence is insufficient.
+
+Use `tools/integrations/_lifecycle.md` to manage the state transition from confirmed candidate to connected-and-verified integration. This file is only the config-flow helper once the lifecycle is already in `CONNECTING`.
 
 Present the results as candidates, not as implied action requests. Do not start a new config flow or attempt an add-device action until the user explicitly confirms the candidate they want to connect.
 
@@ -257,7 +265,7 @@ Use `ha_search_entities` to discover new devices from the integration.
 Show the user what new devices were found. Count the setup as complete only after one new non-system entity was added relative to the baseline and you verified one read or control action against it.
 
 ### Error Handling
-Before telling the user an integration flow is stuck, follow the recovery ladder in `tools/_errors.md`.
+Before telling the user an integration flow is stuck, follow the recovery ladder in `tools/_errors.md`, then return to the current lifecycle phase in `tools/integrations/_lifecycle.md`.
 
 - **`already_in_progress`**: Inspect the pending flow, retry once, and only ask the user before deleting a stale flow or making a new config-flow choice.
 - **`no_devices`**: Follow the recovery ladder in `tools/_errors.md`, then ask the user to verify their region and that devices are registered in their app (Mi Home, LG ThinQ, etc.) if the local checks are clean.

--- a/tools/integrations/_lifecycle.md
+++ b/tools/integrations/_lifecycle.md
@@ -1,0 +1,80 @@
+# Integrations — Lifecycle Harness
+
+Use this orchestration skill after `tools/integrations/_discovery.md` has collected evidence and the user has confirmed which candidate or integration path they want to pursue.
+
+Primary route:
+
+`tools/integrations/_discovery.md` → `tools/integrations/_lifecycle.md` → `tools/integrations/_guide.md`
+
+`tools/integrations/_guide.md` is the config-flow helper used during `CONNECTING`. It is not the entrypoint for discovery or candidate selection.
+
+## State Sequence
+
+`DISCOVERED → IDENTIFIED → INTEGRATION_SELECTED → CONNECTING → CONNECTED → VERIFIED → SKILL_GENERATED`
+
+Move forward only when the current state's exit condition is satisfied. If a state fails, use the failure handling rules below instead of improvising a new path.
+
+## State Rules
+
+### DISCOVERED
+
+- **Entry condition:** `tools/integrations/_discovery.md` produced one or more candidates, or explicitly reported that it found none.
+- **Required data:** passive signals, active fallback evidence if used, confidence level, and whether the user has already confirmed a candidate.
+- **Allowed actions:** summarize the candidates, explain what evidence supports them, and ask the user which path to pursue.
+- **Exit condition:** the user either confirms one candidate / integration path or declines all discovered candidates.
+- **Failure handling:** if discovery found nothing, say so plainly, list which passive/active sources were checked, and stop. Do not start a config flow without a confirmed target.
+
+### IDENTIFIED
+
+- **Entry condition:** the user chose a candidate from discovery.
+- **Required data:** likely integration domain, likely device or service type, local-vs-cloud expectation, and any prerequisites already known.
+- **Allowed actions:** confirm the intended integration domain, call out ambiguity if multiple domains fit, and ask only the minimum clarifying question needed to resolve that ambiguity.
+- **Exit condition:** one integration domain is selected for the chosen candidate.
+- **Failure handling:** if the evidence does not support a single reasonable integration domain, stop and tell the user what remains ambiguous instead of guessing.
+
+### INTEGRATION_SELECTED
+
+- **Entry condition:** a concrete integration domain is known.
+- **Required data:** selected integration domain, whether it is built-in or needs prerequisite install work, and whether the user already approved the mutation step.
+- **Allowed actions:** present the integration path, remind the user that discovery was read-only, and ask for explicit confirmation before any config-flow start or add-device action.
+- **Exit condition:** the user explicitly confirms that the selected integration should be connected.
+- **Failure handling:** if the user has not confirmed, stay in this state. Do not call `ha_config_entries_flow`, do not add a device, and do not perform prerequisite install work.
+
+### CONNECTING
+
+- **Entry condition:** the user explicitly confirmed the selected integration path.
+- **Required data:** integration domain, current HA state, and any fields needed by the config or prerequisite flow.
+- **Allowed actions:** follow `tools/integrations/_guide.md` for dashboard routing, config-flow walking, OAuth handling, and recovery guidance.
+- **Exit condition:** Home Assistant returns a created config entry or equivalent success signal for the selected integration.
+- **Failure handling:** use the recovery ladder in `tools/_errors.md` and then return to the current lifecycle state. If the failure changes the user-facing choice set, pause and ask instead of silently switching paths.
+
+### CONNECTED
+
+- **Entry condition:** the integration exists in Home Assistant.
+- **Required data:** the baseline entity set from before the integration work, the current entity set, and any newly discovered devices exposed by the config entry.
+- **Allowed actions:** inspect entities, compare against the baseline, and identify device-backed, non-system entities that were not present before the connection attempt.
+- **Exit condition:** at least one new device-backed, non-system entity is attributable to the selected integration.
+- **Failure handling:** if the integration is present but exposes no new qualifying entity, tell the user that the integration connected without producing a first-win device and stop before claiming success.
+
+### VERIFIED
+
+- **Entry condition:** at least one new device-backed, non-system entity exists.
+- **Required data:** one concrete read or control action that can be safely verified against the new entity set.
+- **Allowed actions:** perform one read or control action and confirm the observed result.
+- **Exit condition:** one verified read or control action succeeds against an entity that came from the selected integration path.
+- **Failure handling:** if verification fails, report the exact failed step and stay out of `SKILL_GENERATED`. A connected-but-unverified integration is not a completed first win.
+
+### SKILL_GENERATED
+
+- **Entry condition:** the first-win verification succeeded.
+- **Required data:** integration domain, connected devices, entity IDs, and any quirks learned during the flow.
+- **Allowed actions:** follow the skill auto-generation rules in `TOOLS.md` to update integration/device knowledge files.
+- **Exit condition:** repo knowledge reflects the newly connected integration or devices.
+- **Failure handling:** if documentation generation cannot be completed immediately, tell the user the integration is connected and verified, then record the missing knowledge-file follow-up explicitly instead of silently dropping it.
+
+## Failure Handling Rules
+
+- Preserve the approval boundary: discovery is read-only; integration selection, config-flow start, and add-device actions require explicit user confirmation.
+- When a failure happens in `CONNECTING`, use `tools/_errors.md` first, then return to the lifecycle state that failed.
+- When a failure changes which integration path is viable, stop and ask rather than auto-switching to a different integration.
+- Do not claim success until the flow reaches `VERIFIED`.


### PR DESCRIPTION
## Summary
- add the P2 integration workflow docs for discovery, lifecycle, and config-flow handoff
- vendor the Home Assistant best-practices pack and add a refresh script for automation drafting
- add the deterministic P2 scenario harness, fixtures, tests, and validation reports

## Testing
- [x] `python3 -m unittest tests.test_p2_scenario_harness -v`
- [x] `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v`

## Checklist
- [x] discovery-first routing is documented and tested
- [x] automation Step 4 loads the best-practices pack as advisory guidance
- [x] deterministic scenario fixtures and validation docs are included

## Notes
- follow-up CI cleanup will happen on a separate branch after this PR merges
