### PR TITLE
test: harden approval-gate CI coverage

### DIFF
--- a/docs/p2-ci-hardening/checklist.md
+++ b/docs/p2-ci-hardening/checklist.md
@@ -1,0 +1,11 @@
+# P2 CI Improvement Checklist
+
+- [x] Extract approval rules from `scripts/approval-gate.py` into a small shared policy module.
+- [x] Keep `scripts/approval-gate.py` as a thin wrapper around that policy.
+- [x] Add focused unit tests for the policy rules directly.
+- [x] Narrow `tests/test_approval_gate.py` to wrapper behavior only.
+- [x] Make `tests/test_p2_scenario_harness.py` actually execute `confirmation-boundary`.
+- [x] Keep `discovery-routing` and `automation-step4`, but make fixture expectations drive assertions more directly where useful.
+- [x] Update `docs/p2-scenario-harness/validation-report.md` so it matches real harness coverage exactly.
+- [x] Re-run the focused suites and confirm both the standalone harness command and the broader suite pass.
+- [ ] Optional cleanup: reduce doc-string assertions for enforceable rules that are now covered by code.

--- a/docs/p2-ci-hardening/issue.md
+++ b/docs/p2-ci-hardening/issue.md
@@ -1,0 +1,116 @@
+# P2 CI Hardening Issue Document
+
+**Date:** 2026-04-20
+**Scope:** Approval-gate / P2 scenario harness CI hardening in the local-only test harness
+**Analyst:** Codex
+
+## Summary
+
+The approval gate and P2 scenario harness already provide deterministic local-only coverage, but this follow-up cycle surfaced five scoped findings across policy extraction, scenario semantics, representative gate coverage, and validation accuracy. The current issue document tracks the original CI-hardening gaps plus the two review-discovered follow-up gaps that were added after the first code-review pass.
+
+## Intent
+
+**Goal:** Make the approval-gate and P2 harness tests honest, deterministic, and easier to maintain without introducing any Home Assistant, MCP, or network dependency.
+**Priority ranking:** Deterministic local behavior > single source of truth for approval policy > minimal diff size > doc cleanup
+**Decision boundaries:** I can refactor repo-local Python modules, tighten tests, and update repo-local validation docs. I should not introduce live HA/MCP/LLM dependencies or broaden scope beyond approval-policy / harness hardening.
+**Stop rules:** Pause if the refactor would require a packaging change outside this worktree, if focused tests reveal unrelated breakage that changes the scope materially, or if the real approval-gate wrapper cannot stay as the scenario execution path.
+
+## Findings
+
+### P1: Approval policy logic is embedded in the wrapper script
+
+**Severity:** Medium
+**Category:** Reliability
+**Affected components:** `scripts/approval-gate.py`, `tests/test_approval_gate.py`
+
+**Description:** The gated-tool list, confirmation parsing, transcript extraction, and config-flow follow-up logic currently live inside `scripts/approval-gate.py`. That keeps the standalone hook working, but it prevents focused unit tests from exercising the approval policy directly and makes the wrapper test file carry both policy and subprocess responsibilities.
+
+**Impact:** Approval behavior can drift between what the wrapper script does and what CI tests claim to cover. Failures are harder to localize because the current tests validate policy rules only through subprocess execution.
+
+**Success criteria:**
+- [ ] A shared policy module provides the approval-rule decisions used by `scripts/approval-gate.py`.
+- [ ] Focused unit tests exercise the approval policy directly without shelling out.
+- [ ] `tests/test_approval_gate.py` covers wrapper/subprocess behavior only.
+
+---
+
+### P2: The standalone harness suite does not execute `confirmation-boundary`
+
+**Severity:** Medium
+**Category:** Test Coverage
+**Affected components:** `tests/test_p2_scenario_harness.py`, `tests/fixtures/p2_scenario_harness/confirmation-boundary.json`
+
+**Description:** The harness fixtures and validation report list `confirmation-boundary` as covered, but the standalone harness suite currently validates only the schema/load path for that fixture. It does not run the real `scripts/approval-gate.py` against that scenario as a behavior test.
+
+**Impact:** The recommended standalone harness command can pass while not actually proving one of the scenarios it claims to cover. That weakens CI confidence and makes the validation doc inaccurate.
+
+**Success criteria:**
+- [ ] `tests/test_p2_scenario_harness.py` executes the `confirmation-boundary` fixture through the real approval-gate wrapper.
+- [ ] Scenario assertions are driven by fixture expectations where practical, so fixture drift is caught by the behavior tests.
+- [ ] The standalone harness command remains deterministic and local-only.
+
+---
+
+### P3: Harness validation docs overstate current coverage
+
+**Severity:** Low
+**Category:** Documentation
+**Affected components:** `docs/p2-scenario-harness/validation-report.md`, `docs/p2-ci-hardening/validation-report.md`
+
+**Description:** The existing harness validation report says the standalone harness command covers `discovery-routing`, `confirmation-boundary`, and `automation-step4`, but the current suite does not truly execute all three scenarios as behavior tests.
+
+**Impact:** CI documentation can mislead future maintainers about what is enforced by tests versus what is only listed in fixtures or docs.
+
+**Success criteria:**
+- [ ] `docs/p2-scenario-harness/validation-report.md` matches real harness coverage exactly.
+- [ ] The CI hardening validation report records the focused verification commands and their fresh results.
+
+---
+
+### P4: `confirmation-boundary` still proves the follow-up exemption instead of fresh confirmation
+
+**Severity:** Medium
+**Category:** Test Coverage
+**Affected components:** `tests/fixtures/p2_scenario_harness/confirmation-boundary.json`, `tests/test_p2_scenario_harness.py`, `docs/p2-scenario-harness/validation-report.md`
+
+**[DISCOVERED DURING IMPLEMENTATION]**
+
+**Description:** The current `confirmation-boundary` fixture names its positive path as confirmation coverage, but that tool run includes `flow_id`. The approval policy allows follow-up config-flow steps before checking transcript confirmation, so the scenario is actually proving the follow-up exemption rather than an explicitly confirmed fresh start.
+
+**Impact:** The standalone harness and validation docs overstate what they prove. A misleading positive-path claim weakens CI trust even though the underlying wrapper behavior is deterministic.
+
+**Success criteria:**
+- [ ] `confirmation-boundary` executes a denied fresh config-flow start and an allowed explicitly confirmed fresh config-flow start.
+- [ ] `discovery-routing` remains the scenario that covers the allowed follow-up exemption.
+- [ ] Harness and validation docs describe those boundaries accurately.
+
+---
+
+### P5: Representative non-config-flow gated coverage regressed during the refactor
+
+**Severity:** Medium
+**Category:** Test Coverage
+**Affected components:** `tests/test_approval_gate_policy.py`, `tests/test_approval_gate.py`, `scripts/approval_gate_policy.py`
+
+**[DISCOVERED DURING IMPLEMENTATION]**
+
+**Description:** The shared policy still gates device, system, and HACS mutations, but the direct policy tests now focus only on config-flow behavior plus one read-only allow path. The wrapper suite also dropped the old `ha_update_device` deny check.
+
+**Impact:** CI would not catch a regression that accidentally removes representative non-config-flow mutations from `GATED_TOOLS`.
+
+**Success criteria:**
+- [ ] The direct policy tests include at least one denied non-config-flow gated tool.
+- [ ] The wrapper subprocess tests include at least one denied non-config-flow gated tool.
+- [ ] The approval-gate validation report records the refreshed coverage evidence.
+
+## Accepted Residual Risks
+
+None.
+
+## Dependencies Between Findings
+
+- P1 should land before narrowing wrapper tests so the new policy unit tests have a stable shared module to target.
+- P2 depends on P1 only insofar as the harness should continue to execute the real wrapper script after the refactor.
+- P3 depends on the final post-change test runs from P1 and P2.
+- P4 depends on P2 because it refines the scenario semantics after the harness execution gap was first closed.
+- P5 depends on P1 because it extends the shared-policy coverage added by the refactor.

--- a/docs/p2-ci-hardening/plan.md
+++ b/docs/p2-ci-hardening/plan.md
@@ -1,0 +1,108 @@
+# P2 CI Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the approval-gate policy a single executable source of truth and make the standalone P2 harness command exercise exactly the scenarios it claims.
+
+**Architecture:** Split the approval decision logic into a small repo-local policy module imported by the existing wrapper script. Cover policy decisions directly with unit tests, keep wrapper tests focused on subprocess behavior, then tighten the scenario harness so each fixture-backed scenario proves its documented boundary using the real wrapper path.
+
+**Tech Stack:** Python 3, `unittest`, repo-local fixture JSON, markdown validation docs
+
+---
+
+### Task 1: Extract the approval policy and cover it directly
+
+**Files:**
+- Create: `scripts/approval_gate_policy.py`
+- Modify: `scripts/approval-gate.py`
+- Create: `tests/test_approval_gate_policy.py`
+- Modify: `tests/test_approval_gate.py`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Add direct unit tests for:
+- denied new config-flow start without explicit confirmation
+- allowed confirmed start
+- allowed follow-up config-flow step with `flow_id`
+- allowed passive/non-gated tool
+- confirmation parsing boundaries and transcript extraction edge cases
+
+- [ ] **Step 2: Run policy tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_approval_gate_policy -v`
+Expected: FAIL because the shared policy module does not exist yet.
+
+- [ ] **Step 3: Implement the shared policy module and thin wrapper**
+
+Move gated-tool constants and decision helpers into `scripts/approval_gate_policy.py`, keep `scripts/approval-gate.py` responsible for stdin/stdout hook I/O only, and have wrapper tests validate subprocess behavior and fail-open handling.
+
+- [ ] **Step 4: Run focused approval-gate tests**
+
+Run: `python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v`
+Expected: PASS
+
+### Task 2: Make the scenario harness execute its claimed boundaries
+
+**Files:**
+- Modify: `tests/test_p2_scenario_harness.py`
+- Modify: `docs/p2-scenario-harness/validation-report.md`
+- Modify: `tests/test_automation_docs.py` or `tests/test_integrations_docs.py` only if obsolete doc-string assertions need trimming
+
+- [ ] **Step 1: Write failing harness assertions**
+
+Add a behavior test that loads `confirmation-boundary.json`, executes both tool runs through the real `scripts/approval-gate.py`, and asserts outcomes from the fixture’s `expect` values. Tighten `discovery-routing` and `automation-step4` to read expected values from fixtures where that improves drift detection.
+
+- [ ] **Step 2: Run the standalone harness suite to verify the new assertions fail or expose the current gap**
+
+Run: `python3 -m unittest tests.test_p2_scenario_harness -v`
+Expected: FAIL until the harness truly exercises `confirmation-boundary` and the docs align with real coverage.
+
+- [ ] **Step 3: Implement the harness/doc updates**
+
+Refactor the harness tests for fixture-driven assertions, keep scenario execution local-only, and update `docs/p2-scenario-harness/validation-report.md` to describe the real scenario coverage.
+
+- [ ] **Step 4: Run the required validation commands**
+
+Run:
+- `python3 -m unittest tests.test_p2_scenario_harness -v`
+- `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v`
+
+Expected: PASS for both commands.
+
+### Task 3: Fix the review follow-up gaps in scenario semantics and representative gate coverage
+
+**Files:**
+- Modify: `tests/fixtures/p2_scenario_harness/confirmation-boundary.json`
+- Modify: `tests/fixtures/p2_scenario_harness/README.md`
+- Modify: `tests/test_p2_scenario_harness.py`
+- Modify: `docs/p2-scenario-harness/validation-report.md`
+- Modify: `tests/test_approval_gate_policy.py`
+- Modify: `tests/test_approval_gate.py`
+- Modify: `docs/p2-ci-hardening/validation-report.md`
+
+- [ ] **Step 1: Write failing regression expectations for the review findings**
+
+Change `confirmation-boundary` to expect an allowed explicitly confirmed fresh start instead of a `flow_id` follow-up, and add representative non-config-flow deny coverage for the approval gate tests.
+
+- [ ] **Step 2: Run focused tests to expose the current gaps**
+
+Run:
+- `python3 -m unittest tests.test_p2_scenario_harness -v`
+- `python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v`
+
+Expected:
+- the harness suite fails until `confirmation-boundary` stops using the follow-up exemption as its positive path
+- the approval-gate suites pass once the new representative deny coverage is added, because that finding is a coverage gap rather than a behavior bug
+
+- [ ] **Step 3: Update fixtures, tests, and docs**
+
+Make `confirmation-boundary` a fresh-start confirmation scenario, keep the follow-up exemption coverage in `discovery-routing`, restore representative non-config-flow deny coverage in policy and wrapper tests, and align both validation reports with the real boundaries.
+
+- [ ] **Step 4: Re-run the required suites and refresh validation evidence**
+
+Run:
+- `python3 -m unittest tests.test_p2_scenario_harness -v`
+- `python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v`
+- `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v`
+
+Expected: PASS for all commands.

--- a/docs/p2-ci-hardening/rdw-state.json
+++ b/docs/p2-ci-hardening/rdw-state.json
@@ -1,0 +1,115 @@
+{
+  "workflow_id": "rdw-20260420-p2-ci-hardening",
+  "started": "2026-04-20T00:00:00+08:00",
+  "current_stage": "complete",
+  "artifacts": {
+    "issue_doc": "docs/p2-ci-hardening/issue.md",
+    "plan_doc": "docs/p2-ci-hardening/plan.md",
+    "validation_report": "docs/p2-ci-hardening/validation-report.md"
+  },
+  "stages_completed": [
+    "document",
+    "plan",
+    "implement",
+    "validate"
+  ],
+  "phases": {
+    "total": 3,
+    "completed": [
+      "Task 1",
+      "Task 2",
+      "Task 3"
+    ],
+    "current": null,
+    "failed": []
+  },
+  "review_log": [
+    {
+      "stage": "document",
+      "round": 1,
+      "result": "PASS",
+      "notes": [
+        "Intent section includes goal, priorities, decision boundaries, and stop rules.",
+        "Three scoped findings cover policy extraction, real scenario execution, and validation-doc drift."
+      ]
+    },
+    {
+      "stage": "plan",
+      "round": 1,
+      "result": "PASS",
+      "notes": [
+        "Plan maps P1 to Task 1 and P2/P3 to Task 2.",
+        "TDD and required verification commands are called out explicitly."
+      ]
+    },
+    {
+      "stage": "implement",
+      "round": 1,
+      "result": "PASS",
+      "notes": [
+        "Extracted approval logic to scripts/approval_gate_policy.py and narrowed wrapper tests to wrapper I/O behavior.",
+        "Harness now executes confirmation-boundary with fixture-driven expectations and the scenario validation doc matches real coverage."
+      ]
+    },
+    {
+      "stage": "validate",
+      "round": 1,
+      "result": "PASS",
+      "notes": [
+        "python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v -> 11 tests, 0 failures, 0 errors.",
+        "python3 -m unittest tests.test_p2_scenario_harness -v -> 6 tests, 0 failures, 0 errors.",
+        "python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v -> 16 tests, 0 failures, 0 errors."
+      ]
+    },
+    {
+      "stage": "implement",
+      "round": 2,
+      "result": "ISSUES",
+      "notes": [
+        "Code review found that confirmation-boundary still used the flow_id follow-up exemption as its positive path.",
+        "Code review also found representative non-config-flow gated coverage had regressed from the wrapper and policy test suites."
+      ]
+    },
+    {
+      "stage": "implement",
+      "round": 3,
+      "result": "PASS",
+      "notes": [
+        "Reworked confirmation-boundary into a true fresh-start confirmation scenario and kept follow-up exemption coverage in discovery-routing.",
+        "Restored representative non-config-flow gated coverage in both policy and wrapper approval-gate tests."
+      ]
+    },
+    {
+      "stage": "validate",
+      "round": 2,
+      "result": "PASS",
+      "notes": [
+        "python3 -m unittest tests.test_p2_scenario_harness -v -> 6 tests, 0 failures, 0 errors.",
+        "python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v -> 13 tests, 0 failures, 0 errors.",
+        "python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v -> 17 tests, 0 failures, 0 errors."
+      ]
+    },
+    {
+      "stage": "implement",
+      "round": 4,
+      "result": "PASS",
+      "notes": [
+        "A bounded follow-up code review confirmed P4 and P5 were fixed in the exercised paths.",
+        "The only remaining note was a stale issue-doc summary line, which was corrected inline."
+      ]
+    }
+  ],
+  "tier": {
+    "level": 1,
+    "label": "Light",
+    "rationale": "Three scoped local-only CI hardening findings with a requested audit trail."
+  },
+  "discoveries": [
+    "P4: confirmation-boundary currently proves the follow-up exemption rather than an explicitly confirmed fresh start.",
+    "P5: representative non-config-flow gated coverage regressed from the approval-gate test suites."
+  ],
+  "learnings_captured": [
+    "A confirmation-boundary scenario must not include flow_id when it claims to prove affirmative confirmation; discovery-routing already covers the follow-up exemption.",
+    "When extracting policy into a shared module, keep at least one representative non-config-flow gated mutation in both direct policy tests and wrapper subprocess tests."
+  ]
+}

--- a/docs/p2-ci-hardening/validation-report.md
+++ b/docs/p2-ci-hardening/validation-report.md
@@ -1,0 +1,58 @@
+# Validation Report
+
+**Date:** 2026-04-20
+**Issue document:** `docs/p2-ci-hardening/issue.md`
+**Total findings:** 5
+**Passed:** 5 | **Failed:** 0 | **Skipped:** 0
+
+## Results
+
+### P1: Approval policy logic is embedded in the wrapper script - PASS
+- [x] Shared policy module extracted.
+  Evidence: `scripts/approval_gate_policy.py` now contains the gated-tool list, transcript parsing, confirmation matching, follow-up config-flow check, denial-reason builder, and `evaluate_payload()`. `scripts/approval-gate.py` now handles only hook stdin/stdout and delegates decisions to the policy module.
+- [x] Focused unit tests exercise the approval policy directly.
+  Evidence: Ran `python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v` on 2026-04-20. Result: 13 tests ran, 0 failures, 0 errors. Direct policy tests cover denied starts, confirmed starts, follow-up config-flow allowance, passive tools, representative device-mutation denial, transcript parsing, and confirmation-length boundaries.
+- [x] Wrapper tests cover subprocess behavior only.
+  Evidence: The same 13-test run includes 6 wrapper tests that verify structured deny output, silent allow paths, representative device-mutation denial, and malformed-input fail-open behavior through the real `scripts/approval-gate.py` entrypoint.
+
+### P2: The standalone harness suite does not execute `confirmation-boundary` - PASS
+- [x] `tests/test_p2_scenario_harness.py` executes `confirmation-boundary` through the real wrapper.
+  Evidence: Ran `python3 -m unittest tests.test_p2_scenario_harness -v` on 2026-04-20. Result: 6 tests ran, 0 failures, 0 errors. `test_confirmation_boundary_executes_fixture_behavior` executes a denied fresh start and an allowed explicitly confirmed fresh start via `scripts/approval-gate.py`.
+- [x] Fixture expectations drive scenario assertions directly where useful.
+  Evidence: `confirmation-boundary.json` now declares `denied_start`, `confirmed_start`, `denied_transcript`, and `confirmed_transcript`; the harness test consumes those keys directly and asserts that the positive path is a fresh start without `flow_id`. `discovery-routing` continues to cover the allowed follow-up exemption, and `automation-step4` continues to assert fixture-defined expectations where applicable.
+- [x] The harness remains deterministic and local-only.
+  Evidence: The standalone harness run succeeded using repo-local fixture JSON, repo-local markdown docs, and the local `scripts/approval-gate.py` subprocess only. No live Home Assistant instance, MCP server, or network dependency was required.
+
+### P3: Harness validation docs overstate current coverage - PASS
+- [x] `docs/p2-scenario-harness/validation-report.md` matches real harness coverage.
+  Evidence: The report now records 6 executed tests and describes the exact behavior coverage for `discovery-routing`, `confirmation-boundary`, and `automation-step4`, including the distinction between the follow-up exemption and a confirmed fresh start.
+- [x] Fresh CI-hardening validation evidence is recorded.
+  Evidence: Ran `python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v` on 2026-04-20. Result: 17 tests ran, 0 failures, 0 errors.
+
+### P4: `confirmation-boundary` still proves the follow-up exemption instead of fresh confirmation - PASS
+- [x] `confirmation-boundary` now executes a denied fresh config-flow start and an allowed explicitly confirmed fresh config-flow start.
+  Evidence: Ran `python3 -m unittest tests.test_p2_scenario_harness -v` on 2026-04-20. Result: 6 tests ran, 0 failures, 0 errors. `test_confirmation_boundary_executes_fixture_behavior` now asserts that the allowed path omits `flow_id` and succeeds only because the transcript is affirmative.
+- [x] `discovery-routing` remains the scenario that covers the allowed follow-up exemption.
+  Evidence: The same harness run still executes `discovery-routing` with a `flow_id` follow-up tool run and asserts the allowed follow-up expectation separately from `confirmation-boundary`.
+- [x] Harness and validation docs describe those boundaries accurately.
+  Evidence: `tests/fixtures/p2_scenario_harness/README.md`, `docs/p2-scenario-harness/validation-report.md`, and this report now distinguish explicitly confirmed fresh starts from the follow-up exemption path.
+
+### P5: Representative non-config-flow gated coverage regressed during the refactor - PASS
+- [x] The direct policy tests include a denied non-config-flow gated tool.
+  Evidence: Ran `python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v` on 2026-04-20. Result: 13 tests ran, 0 failures, 0 errors. `test_denies_device_mutation_without_confirmation` exercises `mcp__ha-mcp__ha_update_device` at the policy layer.
+- [x] The wrapper subprocess tests include a denied non-config-flow gated tool.
+  Evidence: The same 13-test run includes `test_wrapper_denies_device_mutation_without_confirmation`, which verifies the real wrapper emits a deny decision for `ha_update_device`.
+- [x] The approval-gate validation report records the refreshed coverage evidence.
+  Evidence: This validation report and `rdw-state.json` now record the expanded 13-test approval-gate coverage alongside the required harness and broader suite runs.
+
+## Accepted Residual Risks
+
+None.
+
+## New Issues Discovered
+
+None.
+
+## Verdict
+
+ALL PASS for findings P1-P5. The approval policy remains a single executable source of truth, `confirmation-boundary` now proves an explicitly confirmed fresh start instead of a `flow_id` exemption, representative non-config-flow gated coverage is restored, and the validation docs match the tested boundaries.

--- a/docs/p2-scenario-harness/validation-report.md
+++ b/docs/p2-scenario-harness/validation-report.md
@@ -21,10 +21,16 @@ python3 -m unittest tests.test_p2_scenario_harness -v
 
 Fresh run on 2026-04-20:
 
-- 5 tests executed
+- 6 tests executed
 - 0 failures
 - 0 errors
 
 ## Notes
 
-This harness is intentionally deterministic. It exercises the repo-local P2 policy path without a live Home Assistant instance and uses the real approval gate subprocess plus markdown docs under `tools/` as inputs.
+This harness is intentionally deterministic. It exercises the repo-local P2 policy path without a live Home Assistant instance and uses the real `scripts/approval-gate.py` subprocess plus markdown docs under `tools/` as inputs.
+
+Behavior coverage in the standalone harness suite is:
+
+- `discovery-routing`: executes the read-only discovery allow path, the denied config-flow start, and the allowed follow-up exemption path for an in-progress config flow.
+- `confirmation-boundary`: executes the denied config-flow start and the allowed explicitly confirmed fresh config-flow start using the fixture-defined transcripts.
+- `automation-step4`: verifies the Step 4 document boundary and advisory pack-loading contract from the fixture-defined expectations.

--- a/scripts/approval-gate.py
+++ b/scripts/approval-gate.py
@@ -22,54 +22,8 @@ Scope:
 """
 
 import json
-import re
 import sys
-from pathlib import Path
-
-# Tools that require explicit user confirmation before executing.
-# Keep this list aligned with the "Confirmation required" rules in CLAUDE.md.
-GATED_TOOLS = frozenset({
-    # Automations
-    "mcp__ha-mcp__ha_config_set_automation",
-    "mcp__ha-mcp__ha_config_remove_automation",
-    # Scripts
-    "mcp__ha-mcp__ha_config_set_script",
-    "mcp__ha-mcp__ha_config_remove_script",
-    # Integrations
-    "mcp__ha-mcp__ha_config_entries_flow",
-    "mcp__ha-mcp__ha_delete_config_entry",
-    "mcp__ha-mcp__ha_set_integration_enabled",
-    # Devices
-    "mcp__ha-mcp__ha_remove_device",
-    "mcp__ha-mcp__ha_update_device",
-    "mcp__ha-mcp__ha_rename_entity",
-    # System operations
-    "mcp__ha-mcp__ha_restart",
-    "mcp__ha-mcp__ha_reload_core",
-    "mcp__ha-mcp__ha_backup_restore",
-    # HACS (installs third-party code)
-    "mcp__ha-mcp__ha_hacs_download",
-    "mcp__ha-mcp__ha_hacs_add_repository",
-})
-
-# Affirmative patterns — the last user message must match one of these
-# for the gated tool call to proceed. Case-insensitive, anchored to start.
-CONFIRMATION_PATTERNS = [
-    # English
-    r"^\s*(yes|yeah|yep|yup|y|ok|okay|sure|confirm|confirmed|proceed|do it|go ahead|alright|approved?)\b",
-    # Chinese (simplified + traditional)
-    r"^\s*(是|是的|好|好的|确认|確認|继续|繼續|可以|行|同意|批准)",
-    # Spanish
-    r"^\s*(sí|si|claro|adelante|confirmo|de acuerdo)\b",
-    # French
-    r"^\s*(oui|d'accord|continuez|confirmé|allez-y)\b",
-    # German
-    r"^\s*(ja|bestätigt|weiter|mach)\b",
-    # Japanese
-    r"^\s*(はい|承認|進めて|了解)",
-    # Malay/Indonesian
-    r"^\s*(ya|boleh|setuju|teruskan)\b",
-]
+from approval_gate_policy import evaluate_payload
 
 
 def emit_decision(decision: str, reason: str) -> None:
@@ -85,71 +39,6 @@ def emit_decision(decision: str, reason: str) -> None:
     sys.exit(0)
 
 
-def extract_last_user_text(transcript_path: str) -> str | None:
-    """Return the text of the most recent user message in the transcript, or None."""
-    try:
-        path = Path(transcript_path)
-        if not path.is_file():
-            return None
-        with path.open("r", encoding="utf-8") as f:
-            lines = f.readlines()
-    except Exception:
-        return None
-
-    for line in reversed(lines):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        if entry.get("type") != "user":
-            continue
-
-        message = entry.get("message", {})
-        content = message.get("content")
-
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            texts = []
-            for part in content:
-                if not isinstance(part, dict):
-                    continue
-                # Skip tool_result parts — those are not real user messages
-                if part.get("type") == "tool_result":
-                    return None
-                if part.get("type") == "text":
-                    texts.append(part.get("text", ""))
-            if texts:
-                return " ".join(texts)
-        return None
-
-    return None
-
-
-def is_confirmation(text: str) -> bool:
-    normalized = text.strip().lower()
-    # Reject overly long messages — a real confirmation is short
-    if len(normalized) > 80:
-        return False
-    return any(re.search(pat, normalized, re.IGNORECASE) for pat in CONFIRMATION_PATTERNS)
-
-
-def is_follow_up_config_flow(payload: dict) -> bool:
-    """Allow config-flow calls that are already inside an existing flow."""
-    if payload.get("tool_name") != "mcp__ha-mcp__ha_config_entries_flow":
-        return False
-
-    tool_input = payload.get("tool_input")
-    if not isinstance(tool_input, dict):
-        return False
-
-    return "flow_id" in tool_input
-
-
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
@@ -158,43 +47,10 @@ def main() -> None:
         # the bot for non-destructive calls if the harness changes format.
         sys.exit(0)
 
-    if not isinstance(payload, dict):
-        # Unexpected payload shape — fail open so we do not block harmless calls.
+    decision = evaluate_payload(payload)
+    if decision is None:
         sys.exit(0)
-
-    tool_name = payload.get("tool_name", "")
-    if is_follow_up_config_flow(payload):
-        # Existing config-flow step — allow without a fresh confirmation.
-        sys.exit(0)
-
-    if tool_name not in GATED_TOOLS:
-        # Not a gated tool — allow silently
-        sys.exit(0)
-
-    transcript_path = payload.get("transcript_path", "")
-    last_user_text = extract_last_user_text(transcript_path)
-
-    if last_user_text and is_confirmation(last_user_text):
-        # User explicitly confirmed — allow
-        sys.exit(0)
-
-    # Block with instructions for the LLM
-    tool_short = tool_name.replace("mcp__ha-mcp__", "")
-    reason = (
-        f"Approval gate: '{tool_short}' requires explicit user confirmation "
-        "before a persistent configuration action can proceed. The last user "
-        "message was not a clear affirmative ('yes', '好', 'confirm', etc.).\n\n"
-        "REQUIRED STEPS before retrying:\n"
-        "1. Send the user a concise summary of what this action will do "
-        "(name, affected entities, schedule/triggers if applicable).\n"
-        "2. End the message with: \"Reply yes to confirm or no to cancel.\"\n"
-        "3. Wait for the user's next message.\n"
-        "4. Only retry this tool AFTER the user has replied with an "
-        "affirmative (yes/好/ok/confirm).\n\n"
-        "Do not paraphrase the summary — include the exact details so the "
-        "user knows what they're approving."
-    )
-    emit_decision("deny", reason)
+    emit_decision(decision.decision, decision.reason)
 
 
 if __name__ == "__main__":

--- a/scripts/approval_gate_policy.py
+++ b/scripts/approval_gate_policy.py
@@ -1,0 +1,140 @@
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+GATED_TOOLS = frozenset({
+    "mcp__ha-mcp__ha_config_set_automation",
+    "mcp__ha-mcp__ha_config_remove_automation",
+    "mcp__ha-mcp__ha_config_set_script",
+    "mcp__ha-mcp__ha_config_remove_script",
+    "mcp__ha-mcp__ha_config_entries_flow",
+    "mcp__ha-mcp__ha_delete_config_entry",
+    "mcp__ha-mcp__ha_set_integration_enabled",
+    "mcp__ha-mcp__ha_remove_device",
+    "mcp__ha-mcp__ha_update_device",
+    "mcp__ha-mcp__ha_rename_entity",
+    "mcp__ha-mcp__ha_restart",
+    "mcp__ha-mcp__ha_reload_core",
+    "mcp__ha-mcp__ha_backup_restore",
+    "mcp__ha-mcp__ha_hacs_download",
+    "mcp__ha-mcp__ha_hacs_add_repository",
+})
+
+CONFIRMATION_PATTERNS = [
+    r"^\s*(yes|yeah|yep|yup|y|ok|okay|sure|confirm|confirmed|proceed|do it|go ahead|alright|approved?)\b",
+    r"^\s*(是|是的|好|好的|确认|確認|继续|繼續|可以|行|同意|批准)",
+    r"^\s*(sí|si|claro|adelante|confirmo|de acuerdo)\b",
+    r"^\s*(oui|d'accord|continuez|confirmé|allez-y)\b",
+    r"^\s*(ja|bestätigt|weiter|mach)\b",
+    r"^\s*(はい|承認|進めて|了解)",
+    r"^\s*(ya|boleh|setuju|teruskan)\b",
+]
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    decision: str
+    reason: str
+
+
+def extract_last_user_text(transcript_path: str) -> str | None:
+    """Return the text of the most recent user message in the transcript, or None."""
+    try:
+        path = Path(transcript_path)
+        if not path.is_file():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except Exception:
+        return None
+
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if entry.get("type") != "user":
+            continue
+
+        message = entry.get("message", {})
+        content = message.get("content")
+
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            texts = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "tool_result":
+                    return None
+                if part.get("type") == "text":
+                    texts.append(part.get("text", ""))
+            if texts:
+                return " ".join(texts)
+        return None
+
+    return None
+
+
+def is_confirmation(text: str) -> bool:
+    normalized = text.strip().lower()
+    if len(normalized) > 80:
+        return False
+    return any(re.search(pattern, normalized, re.IGNORECASE) for pattern in CONFIRMATION_PATTERNS)
+
+
+def is_follow_up_config_flow(payload: dict) -> bool:
+    """Allow config-flow calls that are already inside an existing flow."""
+    if payload.get("tool_name") != "mcp__ha-mcp__ha_config_entries_flow":
+        return False
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return False
+
+    return "flow_id" in tool_input
+
+
+def build_denial_reason(tool_name: str) -> str:
+    tool_short = tool_name.replace("mcp__ha-mcp__", "")
+    return (
+        f"Approval gate: '{tool_short}' requires explicit user confirmation "
+        "before a persistent configuration action can proceed. The last user "
+        "message was not a clear affirmative ('yes', '好', 'confirm', etc.).\n\n"
+        "REQUIRED STEPS before retrying:\n"
+        "1. Send the user a concise summary of what this action will do "
+        "(name, affected entities, schedule/triggers if applicable).\n"
+        "2. End the message with: \"Reply yes to confirm or no to cancel.\"\n"
+        "3. Wait for the user's next message.\n"
+        "4. Only retry this tool AFTER the user has replied with an "
+        "affirmative (yes/好/ok/confirm).\n\n"
+        "Do not paraphrase the summary — include the exact details so the "
+        "user knows what they're approving."
+    )
+
+
+def evaluate_payload(payload: object) -> GateDecision | None:
+    """Return a deny decision when policy blocks the payload, else None."""
+    if not isinstance(payload, dict):
+        return None
+
+    if is_follow_up_config_flow(payload):
+        return None
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in GATED_TOOLS:
+        return None
+
+    transcript_path = payload.get("transcript_path", "")
+    last_user_text = extract_last_user_text(str(transcript_path))
+    if last_user_text and is_confirmation(last_user_text):
+        return None
+
+    return GateDecision(decision="deny", reason=build_denial_reason(str(tool_name)))

--- a/tests/fixtures/p2_scenario_harness/README.md
+++ b/tests/fixtures/p2_scenario_harness/README.md
@@ -25,8 +25,11 @@ defaults.
     }
   ],
   "expect": {
-    "decision": "deny",
-    "reason_contains": "explicit confirmation"
+    "denied_start": "deny",
+    "confirmed_start": "allow",
+    "reason_contains": "explicit user confirmation",
+    "denied_transcript": "please continue",
+    "confirmed_transcript": "yes"
   }
 }
 ```
@@ -34,3 +37,8 @@ defaults.
 The same shape works for positive and negative paths. A confirmed path uses a
 transcript such as `yes`; a denied path uses a transcript such as `please
 continue`.
+
+For multi-step scenarios, prefer expectation keys that mirror the actual tool
+run boundaries. For example, `confirmation-boundary` records `denied_start`,
+`confirmed_start`, `denied_transcript`, and `confirmed_transcript` so the
+behavior test can assert the real wrapper outcomes directly from the fixture.

--- a/tests/fixtures/p2_scenario_harness/confirmation-boundary.json
+++ b/tests/fixtures/p2_scenario_harness/confirmation-boundary.json
@@ -14,16 +14,16 @@
     {
       "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
       "tool_input": {
-        "handler": "hue",
-        "flow_id": "abc123"
+        "handler": "hue"
       },
       "transcript": "yes"
     }
   ],
   "expect": {
-    "decision": "deny",
-    "reason_contains": "explicit confirmation",
-    "confirmed": "yes",
-    "denied": "please continue"
+    "denied_start": "deny",
+    "confirmed_start": "allow",
+    "reason_contains": "explicit user confirmation",
+    "confirmed_transcript": "yes",
+    "denied_transcript": "please continue"
   }
 }

--- a/tests/test_approval_gate.py
+++ b/tests/test_approval_gate.py
@@ -48,7 +48,7 @@ class ApprovalGateTests(unittest.TestCase):
             transcript_path.unlink(missing_ok=True)
         return result
 
-    def test_new_config_flow_start_requires_confirmation(self) -> None:
+    def test_wrapper_emits_structured_deny_decision(self) -> None:
         result = self._run_gate(
             {
                 "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
@@ -60,8 +60,9 @@ class ApprovalGateTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         decision = json.loads(result.stdout)
         self.assertEqual(decision["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn("Reply yes to confirm or no to cancel.", decision["hookSpecificOutput"]["permissionDecisionReason"])
 
-    def test_confirmed_new_config_flow_start_is_allowed(self) -> None:
+    def test_wrapper_allows_confirmed_call_silently(self) -> None:
         result = self._run_gate(
             {
                 "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
@@ -73,7 +74,7 @@ class ApprovalGateTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, "")
 
-    def test_follow_up_config_flow_step_is_allowed(self) -> None:
+    def test_wrapper_allows_follow_up_step_silently(self) -> None:
         result = self._run_gate(
             {
                 "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
@@ -85,7 +86,19 @@ class ApprovalGateTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, "")
 
-    def test_device_mutation_still_requires_confirmation(self) -> None:
+    def test_wrapper_allows_non_gated_tool_silently(self) -> None:
+        result = self._run_gate(
+            {
+                "tool_name": "mcp__ha-mcp__ha_config_entries_get",
+                "tool_input": {},
+            },
+            transcript_text="please continue",
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_wrapper_denies_device_mutation_without_confirmation(self) -> None:
         result = self._run_gate(
             {
                 "tool_name": "mcp__ha-mcp__ha_update_device",
@@ -97,18 +110,7 @@ class ApprovalGateTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         decision = json.loads(result.stdout)
         self.assertEqual(decision["hookSpecificOutput"]["permissionDecision"], "deny")
-
-    def test_passive_config_entries_get_is_allowed(self) -> None:
-        result = self._run_gate(
-            {
-                "tool_name": "mcp__ha-mcp__ha_config_entries_get",
-                "tool_input": {},
-            },
-            transcript_text="please continue",
-        )
-
-        self.assertEqual(result.returncode, 0)
-        self.assertEqual(result.stdout, "")
+        self.assertIn("ha_update_device", decision["hookSpecificOutput"]["permissionDecisionReason"])
 
     def test_malformed_input_fails_open(self) -> None:
         result = subprocess.run(

--- a/tests/test_approval_gate_policy.py
+++ b/tests/test_approval_gate_policy.py
@@ -1,0 +1,177 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from approval_gate_policy import evaluate_payload, extract_last_user_text, is_confirmation
+
+
+class ApprovalGatePolicyTests(unittest.TestCase):
+    def _write_transcript(self, entries: list[dict]) -> Path:
+        handle = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+        with handle as transcript_file:
+            for entry in entries:
+                transcript_file.write(json.dumps(entry) + "\n")
+        return Path(handle.name)
+
+    def test_denies_new_config_flow_without_confirmation(self) -> None:
+        transcript_path = self._write_transcript(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "please continue",
+                            }
+                        ]
+                    },
+                }
+            ]
+        )
+        try:
+            decision = evaluate_payload(
+                {
+                    "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+                    "tool_input": {"handler": "hue"},
+                    "transcript_path": str(transcript_path),
+                }
+            )
+        finally:
+            transcript_path.unlink(missing_ok=True)
+
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision.decision, "deny")
+        self.assertIn("explicit user confirmation", decision.reason)
+
+    def test_allows_confirmed_new_config_flow(self) -> None:
+        transcript_path = self._write_transcript(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "yes",
+                            }
+                        ]
+                    },
+                }
+            ]
+        )
+        try:
+            decision = evaluate_payload(
+                {
+                    "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+                    "tool_input": {"handler": "hue"},
+                    "transcript_path": str(transcript_path),
+                }
+            )
+        finally:
+            transcript_path.unlink(missing_ok=True)
+
+        self.assertIsNone(decision)
+
+    def test_allows_follow_up_config_flow_step_without_fresh_confirmation(self) -> None:
+        decision = evaluate_payload(
+            {
+                "tool_name": "mcp__ha-mcp__ha_config_entries_flow",
+                "tool_input": {"handler": "hue", "flow_id": "abc123"},
+                "transcript_path": "/tmp/does-not-matter",
+            }
+        )
+
+        self.assertIsNone(decision)
+
+    def test_allows_non_gated_tool(self) -> None:
+        decision = evaluate_payload(
+            {
+                "tool_name": "mcp__ha-mcp__ha_config_entries_get",
+                "tool_input": {},
+                "transcript_path": "/tmp/does-not-matter",
+            }
+        )
+
+        self.assertIsNone(decision)
+
+    def test_denies_device_mutation_without_confirmation(self) -> None:
+        transcript_path = self._write_transcript(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "please continue",
+                            }
+                        ]
+                    },
+                }
+            ]
+        )
+        try:
+            decision = evaluate_payload(
+                {
+                    "tool_name": "mcp__ha-mcp__ha_update_device",
+                    "tool_input": {"device_id": "device-123"},
+                    "transcript_path": str(transcript_path),
+                }
+            )
+        finally:
+            transcript_path.unlink(missing_ok=True)
+
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision.decision, "deny")
+        self.assertIn("ha_update_device", decision.reason)
+
+    def test_extract_last_user_text_ignores_tool_results(self) -> None:
+        transcript_path = self._write_transcript(
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "yes",
+                            }
+                        ]
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "text": "not a real user reply",
+                            }
+                        ]
+                    },
+                },
+            ]
+        )
+        try:
+            text = extract_last_user_text(str(transcript_path))
+        finally:
+            transcript_path.unlink(missing_ok=True)
+
+        self.assertIsNone(text)
+
+    def test_confirmation_requires_short_affirmative_boundary(self) -> None:
+        self.assertTrue(is_confirmation(" yes, go ahead"))
+        self.assertTrue(is_confirmation("确认"))
+        self.assertFalse(is_confirmation("please continue"))
+        self.assertFalse(is_confirmation("yes " + ("really " * 20)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_p2_scenario_harness.py
+++ b/tests/test_p2_scenario_harness.py
@@ -64,6 +64,20 @@ def run_gate(tool_name: str, tool_input: dict, transcript: str) -> subprocess.Co
 
 
 class P2ScenarioHarnessTests(unittest.TestCase):
+    def assert_gate_allows(self, run: dict) -> None:
+        result = run_gate(run["tool_name"], run["tool_input"], run["transcript"])
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def assert_gate_denies(self, run: dict, reason_contains: str) -> None:
+        result = run_gate(run["tool_name"], run["tool_input"], run["transcript"])
+
+        self.assertEqual(result.returncode, 0)
+        decision = json.loads(result.stdout)
+        self.assertEqual(decision["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.assertIn(reason_contains, decision["hookSpecificOutput"]["permissionDecisionReason"])
+
     def test_discovers_named_fixtures(self) -> None:
         names = sorted(path.name for path in FIXTURE_DIR.glob("*.json"))
 
@@ -96,8 +110,10 @@ class P2ScenarioHarnessTests(unittest.TestCase):
         self.assertIn("docs", readme)
         self.assertIn("tool_runs", readme)
         self.assertIn("expect", readme)
-        self.assertIn("confirmed", readme)
-        self.assertIn("denied", readme)
+        self.assertIn("denied_start", readme)
+        self.assertIn("confirmed_start", readme)
+        self.assertIn("denied_transcript", readme)
+        self.assertIn("confirmed_transcript", readme)
 
     def test_discovery_then_confirmation_then_mutation(self) -> None:
         scenario = load_scenario("discovery-routing")
@@ -116,31 +132,25 @@ class P2ScenarioHarnessTests(unittest.TestCase):
 
         discovery_run, denied_run, confirmed_run = scenario["tool_runs"]
 
-        discovery_result = run_gate(
-            discovery_run["tool_name"],
-            discovery_run["tool_input"],
-            discovery_run["transcript"],
-        )
-        self.assertEqual(discovery_result.returncode, 0)
-        self.assertEqual(discovery_result.stdout, "")
+        self.assert_gate_allows(discovery_run)
+        self.assert_gate_denies(denied_run, "explicit user confirmation")
+        self.assert_gate_allows(confirmed_run)
 
-        denied_result = run_gate(
-            denied_run["tool_name"],
-            denied_run["tool_input"],
-            denied_run["transcript"],
-        )
-        self.assertEqual(denied_result.returncode, 0)
-        denied_decision = json.loads(denied_result.stdout)
-        self.assertEqual(denied_decision["hookSpecificOutput"]["permissionDecision"], "deny")
-        self.assertIn("explicit user confirmation", denied_decision["hookSpecificOutput"]["permissionDecisionReason"])
+    def test_confirmation_boundary_executes_fixture_behavior(self) -> None:
+        scenario = load_scenario("confirmation-boundary")
+        guide_doc = (REPO_ROOT / scenario["docs"][0]).read_text(encoding="utf-8")
 
-        confirmed_result = run_gate(
-            confirmed_run["tool_name"],
-            confirmed_run["tool_input"],
-            confirmed_run["transcript"],
-        )
-        self.assertEqual(confirmed_result.returncode, 0)
-        self.assertEqual(confirmed_result.stdout, "")
+        self.assertEqual(scenario["name"], "confirmation-boundary")
+        self.assertIn("Start the flow only after explicit user confirmation", guide_doc)
+        self.assertEqual(scenario["expect"]["denied_start"], "deny")
+        self.assertEqual(scenario["expect"]["confirmed_start"], "allow")
+        self.assertEqual(scenario["expect"]["denied_transcript"], scenario["tool_runs"][0]["transcript"])
+        self.assertEqual(scenario["expect"]["confirmed_transcript"], scenario["tool_runs"][1]["transcript"])
+
+        denied_run, confirmed_run = scenario["tool_runs"]
+        self.assertNotIn("flow_id", confirmed_run["tool_input"])
+        self.assert_gate_denies(denied_run, scenario["expect"]["reason_contains"])
+        self.assert_gate_allows(confirmed_run)
 
     def test_automation_step4_loads_pack_only_when_drafting(self) -> None:
         scenario = load_scenario("automation-step4")
@@ -150,6 +160,10 @@ class P2ScenarioHarnessTests(unittest.TestCase):
 
         self.assertEqual(scenario["name"], "automation-step4")
         self.assertEqual(len(scenario["tool_runs"]), 2)
+        self.assertEqual(scenario["expect"]["general_request"], "no_pack_load")
+        self.assertEqual(scenario["expect"]["drafting_boundary"], "load_pack")
+        self.assertTrue(scenario["expect"]["advisory"])
+        self.assertEqual(scenario["expect"]["authority"], "CLAUDE.md")
         self.assertIn("general automation request", scenario["tool_runs"][0]["transcript"].lower())
         self.assertIn("draft", scenario["tool_runs"][1]["transcript"].lower())
         self.assertIn("Step 4", guide_doc)


### PR DESCRIPTION
## Summary
- Makes sure SmartHub only allows real setup or config changes after clear user confirmation, while still allowing safe read-only actions and follow-up steps in an already-started setup flow.
- Checks those approval rules both directly and through the real command-line gate, so the shared logic and the actual wrapper behave the same way.
- Verifies the local scenario harness really exercises the setup paths it claims to cover, including discovery-first behavior, confirmation boundaries, and the automation drafting boundary.
- Confirms the setup and integration docs still describe the expected flow and machine boundaries correctly.
- Confirms the validation docs match what the tests actually exercise, including the documented harness command and covered scenarios.

## Test Plan
- [x] python3 -m unittest tests.test_p2_scenario_harness -v
- [x] python3 -m unittest tests.test_approval_gate_policy tests.test_approval_gate -v
- [x] python3 -m unittest tests.test_p2_scenario_harness tests.test_approval_gate tests.test_automation_docs tests.test_integrations_docs -v
